### PR TITLE
feat: add optional browser-side access check to success page

### DIFF
--- a/app.py
+++ b/app.py
@@ -41,6 +41,9 @@ CROWDSEC_ALLOWLIST_NAME = os.getenv("CROWDSEC_ALLOWLIST_NAME", "pangolin-ip-rule
 CROWDSEC_CACHE_TTL_SECONDS = int(os.getenv("CROWDSEC_CACHE_TTL_SECONDS", "3600"))  # cache TTL for CrowdSec allowlist entries (~1h)
 # Optional: allow overriding the caller IP via /update?ip=...
 UPDATE_ENDPOINT_ENABLED = os.getenv("UPDATE_ENDPOINT_ENABLED", "false").strip().lower() in ("1", "true", "yes", "on")
+# Optional: browser-side access check shown on the success page
+ACCESS_CHECK_ENABLED = os.getenv("ACCESS_CHECK_ENABLED", "false").strip().lower() in ("1", "true", "yes", "on")
+ACCESS_CHECK_URL = os.getenv("ACCESS_CHECK_URL", "").strip()
 # Mandatory Pangolin custom header gate: both must be set and non-empty
 EXPECTED_PANGOLIN_CUSTOM_HEADER_KEY = os.getenv("EXPECTED_PANGOLIN_CUSTOM_HEADER_KEY", "").strip()
 EXPECTED_PANGOLIN_CUSTOM_HEADER_VALUE = os.getenv("EXPECTED_PANGOLIN_CUSTOM_HEADER_VALUE", "").strip()
@@ -314,7 +317,7 @@ def cleanup_old_ips():
                 if not rec4.get("resources"):
                     state.pop(ip, None)
                     changed = True
-                    
+
         # Always attempt CrowdSec expiration for expired IPs (idempotent)
         try:
             expire_ip_from_targets(ip)
@@ -345,6 +348,8 @@ def _make_image_handler_context() -> dict:
         "update_enabled": UPDATE_ENDPOINT_ENABLED,
         "retention_minutes": RETENTION_MINUTES,
         "crowdsec_enabled": CROWDSEC_ENABLED,
+        "access_check_enabled": ACCESS_CHECK_ENABLED,
+        "access_check_url": ACCESS_CHECK_URL,
         "state": state,
         "state_lock": state_lock,
         "now_utc_iso": now_utc_iso,
@@ -385,6 +390,15 @@ def self_check():
     if not RESOURCE_IDS:
         print("[warn] RESOURCE_IDS is empty; no resources will be managed.")
 
+    if ACCESS_CHECK_ENABLED and not ACCESS_CHECK_URL:
+        print("")
+        print("=" * 60)
+        print("[WARN] ACCESS_CHECK_ENABLED=true but ACCESS_CHECK_URL is not set.")
+        print("       The access check row will not appear on the success page.")
+        print("       Set ACCESS_CHECK_URL to the URL you want to verify.")
+        print("=" * 60)
+        print("")
+
     # Verify state file directory is writable before we need it
     state_dir = os.path.dirname(os.path.abspath(STATE_FILE))
     if not os.path.isdir(state_dir):
@@ -419,7 +433,8 @@ def self_check():
         f"[self-check] OK. listen_port={LISTEN_PORT} state_file={STATE_FILE} "
         f"resources={RESOURCE_IDS} retention_minutes={RETENTION_MINUTES} "
         f"cleanup_interval_minutes={CLEANUP_INTERVAL_MINUTES} rule_priority={RULE_PRIORITY} "
-        f"crowdsec={cs_status} update_endpoint_enabled={UPDATE_ENDPOINT_ENABLED}"
+        f"crowdsec={cs_status} update_endpoint_enabled={UPDATE_ENDPOINT_ENABLED} "
+        f"access_check_enabled={ACCESS_CHECK_ENABLED} access_check_url={ACCESS_CHECK_URL!r}"
     )
 
 

--- a/config.env.sample
+++ b/config.env.sample
@@ -34,3 +34,12 @@ CROWDSEC_CACHE_TTL_SECONDS=3600
 # Only accessible to requests that pass the custom header gate above.
 # Disabled by default for safety.
 UPDATE_ENDPOINT_ENABLED=false
+
+# Optional: browser-side access check on the success page.
+# When enabled, the success page will fetch ACCESS_CHECK_URL directly from the user's
+# browser after check-in and display whether the resource is now reachable (no redirect)
+# or still gated (redirected to Pangolin auth). No CORS configuration required.
+# ACCESS_CHECK_URL should be the root URL of the resource the user is trying to reach,
+# e.g. https://jellyfin.example.com
+ACCESS_CHECK_ENABLED=false
+ACCESS_CHECK_URL=

--- a/image_request_handler.py
+++ b/image_request_handler.py
@@ -4,7 +4,15 @@ from datetime import datetime, timedelta, timezone
 import ipaddress
 
 
-def _build_checkin_html(ip: str, results: dict, retention_minutes: int, last_seen: str, crowdsec_enabled: bool) -> str:
+def _build_checkin_html(
+    ip: str,
+    results: dict,
+    retention_minutes: int,
+    last_seen: str,
+    crowdsec_enabled: bool,
+    access_check_enabled: bool = False,
+    access_check_url: str = "",
+) -> str:
     """Build the HTML checkin response page."""
 
     try:
@@ -47,6 +55,65 @@ def _build_checkin_html(ip: str, results: dict, retention_minutes: int, last_see
 
     details_label = "Technical details" if overall_ok else "What went wrong?"
 
+    # Access check row — only rendered when both enabled and a URL is configured
+    show_access_check = access_check_enabled and bool(access_check_url)
+    if show_access_check:
+        # Escape the URL for safe inline HTML/JS embedding
+        safe_url = (
+            access_check_url
+            .replace("&", "&amp;")
+            .replace('"', "&quot;")
+            .replace("'", "&#39;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+        )
+        access_check_row = (
+            "      <div class=\"status-row\" id=\"access-check-row\">\n"
+            "        <span class=\"label\">\n"
+            "          <svg width=\"14\" height=\"14\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\">"
+            "<path d=\"M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6\"/>"
+            "<polyline points=\"15 3 21 3 21 9\"/><line x1=\"10\" y1=\"14\" x2=\"21\" y2=\"3\"/>"
+            "</svg>\n"
+            f"          <span style=\"font-family:var(--mono);font-size:11px;\">{safe_url}</span>\n"
+            "        </span>\n"
+            "        <span class=\"badge pending\" id=\"access-check-badge\">"
+            "<span class=\"spinner\"></span>Checking&hellip;"
+            "</span>\n"
+            "      </div>"
+        )
+        # JS snippet injected at end of page — runs after DOM is ready
+        # Uses fetch with mode:'no-cors' and redirect:'manual' to detect whether
+        # the target responds directly (opaque = reachable) or redirects to Pangolin
+        # auth (opaqueredirect = not yet whitelisted), without needing CORS headers.
+        access_check_js = (
+            "\n"
+            "  (function() {\n"
+            f"    var url = \"{safe_url}\";\n"
+            "    var badge = document.getElementById('access-check-badge');\n"
+            "    if (!badge) return;\n"
+            "    fetch(url, { method: 'HEAD', mode: 'no-cors', redirect: 'manual', cache: 'no-store' })\n"
+            "      .then(function(r) {\n"
+            "        if (r.type === 'opaqueredirect') {\n"
+            "          // Redirected — Pangolin auth wall still in place for this IP\n"
+            "          badge.className = 'badge err';\n"
+            "          badge.innerHTML = 'Redirected';\n"
+            "        } else {\n"
+            "          // Got a real response (opaque 2xx/3xx from target) — reachable\n"
+            "          badge.className = 'badge ok';\n"
+            "          badge.innerHTML = 'Reachable';\n"
+            "        }\n"
+            "      })\n"
+            "      .catch(function() {\n"
+            "        // Network error — target is down or unreachable entirely\n"
+            "        badge.className = 'badge warn';\n"
+            "        badge.innerHTML = 'Unreachable';\n"
+            "      });\n"
+            "  })();"
+        )
+    else:
+        access_check_row = ""
+        access_check_js = ""
+
     html = (
         "<!DOCTYPE html>\n"
         "<html lang=\"en\">\n"
@@ -65,6 +132,8 @@ def _build_checkin_html(ip: str, results: dict, retention_minutes: int, last_see
         "    --muted:     #6b7390;\n"
         "    --accent:    #4ade80;\n"
         "    --accent-dim:#1a3d28;\n"
+        "    --warn:      #fbbf24;\n"
+        "    --warn-dim:  #3d2e0a;\n"
         "    --err:       #f87171;\n"
         "    --err-dim:   #3d1515;\n"
         "    --mono:      'IBM Plex Mono', monospace;\n"
@@ -140,11 +209,15 @@ def _build_checkin_html(ip: str, results: dict, retention_minutes: int, last_see
         "    padding: 10px 14px; border-radius: 8px; border: 1px solid var(--border); background: var(--bg);\n"
         "  }\n"
         "  .status-row .label { font-size: 13px; color: var(--muted); display: flex; align-items: center; gap: 8px; }\n"
-        "  .status-row .label svg { opacity: .5; }\n"
+        "  .status-row .label svg { opacity: .5; flex-shrink: 0; }\n"
         "  .badge { font-family: var(--mono); font-size: 11px; font-weight: 500; padding: 3px 9px; border-radius: 4px; letter-spacing: .04em; text-transform: uppercase; }\n"
-        "  .badge.ok   { background: var(--accent-dim); color: var(--accent); }\n"
-        "  .badge.skip { background: var(--border);     color: var(--muted); }\n"
-        "  .badge.err  { background: var(--err-dim);    color: var(--err); }\n"
+        "  .badge.ok      { background: var(--accent-dim); color: var(--accent); }\n"
+        "  .badge.skip    { background: var(--border);     color: var(--muted); }\n"
+        "  .badge.err     { background: var(--err-dim);    color: var(--err); }\n"
+        "  .badge.warn    { background: var(--warn-dim);   color: var(--warn); }\n"
+        "  .badge.pending { background: var(--border);     color: var(--muted); display: inline-flex; align-items: center; gap: 6px; }\n"
+        "  @keyframes spin { to { transform: rotate(360deg); } }\n"
+        "  .spinner { width: 9px; height: 9px; border: 1.5px solid var(--muted); border-top-color: transparent; border-radius: 50%; animation: spin .7s linear infinite; display: inline-block; flex-shrink: 0; }\n"
         "  .expiry { font-size: 12px; color: var(--muted); text-align: center; margin-bottom: 20px; line-height: 1.5; }\n"
         "  .expiry span { color: var(--text); font-family: var(--mono); font-size: 12px; }\n"
         "  .details-toggle {\n"
@@ -200,6 +273,7 @@ def _build_checkin_html(ip: str, results: dict, retention_minutes: int, last_see
         "        </span>\n"
         f"        {crowdsec_badge}\n"
         "      </div>\n"
+        f"{access_check_row}\n"
         "    </div>\n"
         "    <p class=\"expiry\">\n"
         f"      Access expires <span>{expires_str}</span><br>\n"
@@ -225,6 +299,7 @@ def _build_checkin_html(ip: str, results: dict, retention_minutes: int, last_see
         "    const open = body.classList.toggle('open');\n"
         "    btn.setAttribute('aria-expanded', open);\n"
         "  }\n"
+        f"{access_check_js}\n"
         "</script>\n"
         "</body>\n"
         "</html>"
@@ -314,6 +389,8 @@ def create_image_request_handler(ctx: dict):
       - update_enabled: bool
       - retention_minutes: int
       - crowdsec_enabled: bool
+      - access_check_enabled: bool
+      - access_check_url: str
       - state: dict
       - state_lock: threading.Lock
       - now_utc_iso: callable () -> str
@@ -456,6 +533,8 @@ def create_image_request_handler(ctx: dict):
                         retention_minutes=ctx.get("retention_minutes", 0),
                         last_seen=ctx["now_utc_iso"](),
                         crowdsec_enabled=ctx.get("crowdsec_enabled", False),
+                        access_check_enabled=ctx.get("access_check_enabled", False),
+                        access_check_url=ctx.get("access_check_url", ""),
                     ))
                 else:
                     payload = (
@@ -521,6 +600,8 @@ def create_image_request_handler(ctx: dict):
                     retention_minutes=ctx.get("retention_minutes", 0),
                     last_seen=now_iso,
                     crowdsec_enabled=ctx.get("crowdsec_enabled", False),
+                    access_check_enabled=ctx.get("access_check_enabled", False),
+                    access_check_url=ctx.get("access_check_url", ""),
                 ))
             else:
                 body = ctx["banner_gif"] if is_gif else ctx["banner_png"]


### PR DESCRIPTION
Adds an optional browser-side reachability check to the post-check-in success page. When enabled, the page fetches a configured URL directly from the user's browser after registration and displays whether the resource is now accessible or still redirecting to Pangolin auth.

Two new environment variables:
- ACCESS_CHECK_ENABLED (default: false)
- ACCESS_CHECK_URL (the resource URL to verify, e.g. https://jellyfin.example.com)

The check uses fetch() with mode: 'no-cors' and redirect: 'manual', which distinguishes a real response (opaque) from a Pangolin auth redirect (opaqueredirect) without requiring any CORS configuration on the target resource.

The success page shows a new status row matching the existing Pangolin and CrowdSec rows, with a spinner while the check is in flight, then resolves to Reachable, Redirected, or Unreachable.

The feature is fully opt-in and has no effect when disabled.