### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/joe-cole1/pangolin-ip-rule-manager/security/code-scanning/1](https://github.com/joe-cole1/pangolin-ip-rule-manager/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/docker-image.yml` with the minimum needed scope.  
For this workflow, `contents: read` is sufficient for `actions/checkout` and the Docker build command shown. Placing it at the workflow root (after `on:` and before `jobs:`) applies to all jobs unless overridden, keeps behavior unchanged, and documents intended least privilege.

No imports, methods, or dependencies are needed—just YAML configuration in the existing workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
