### PR TITLE
v2.2.2 — Internal hardening: state lock, retry auth abort, verbose cleanup logs, expanded test coverage

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -4,9 +4,9 @@ permissions:
 on:
   workflow_dispatch:
   push:
-    branches: [ "master", "dev" ]
+    branches: [ "master" ]
   pull_request:
-    branches: [ "master", "dev" ]
+    branches: [ "master" ]
 
 jobs:
   build:
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.14"]
 
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4

--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@
 
 This project is actively maintained and has a few things in the pipeline worth knowing about before you set it up.
 
-The next release focuses on internal reliability improvements — nothing that changes how you configure or use the service, but fixes that make it more robust under the hood.
-
-After that, the CrowdSec integration is getting a security improvement that will change how the service communicates with CrowdSec. If you're planning to use that feature, it's worth knowing the setup steps will look a little different once that lands. The current approach works, but the new one will be cleaner and safer. The README will be updated when it ships.
+The CrowdSec integration is getting a security improvement that will change how the service communicates with CrowdSec. If you're planning to use that feature, it's worth knowing the setup steps will look a little different once that lands. The current approach works, but the new one will be cleaner and safer. The README will be updated when it ships.
 
 Longer term, the check-in page is getting a visual refresh to better match the Pangolin aesthetic, along with smarter resource link icons that auto-match to the app you're protecting (Jellyfin, Radarr, and so on).
 
@@ -126,9 +124,10 @@ This means a family member with a limited role only ever bootstraps access to th
 3. Pangolin forwards the request, injecting the Remote-User header
    (identifies the authenticated user)
 4. Service reads Remote-User → fail-closed error if absent
-5. Service looks up the user's roleIds in Pangolin
+5. Service looks up the user's roleIds and userId in Pangolin
 6. For each resource in RESOURCE_IDS, service checks whether the
-   user's role is allowed on that resource
+   user's role is allowed on that resource, or whether the user is
+   directly assigned to it — either path grants access
 7. For each permitted resource, service creates an IP bypass rule
    (and adds the IP to CrowdSec if enabled)
 8. Success page shows an "Open <Name>" link for each whitelisted resource
@@ -382,7 +381,7 @@ On startup the service:
 
 1. The `Remote-User` header is read. If absent, the service **fails closed**: it whitelists nothing and returns an error result with the reason in the technical details
 2. The client IP is extracted in priority order: `X-Real-IP` → first entry of `X-Forwarded-For` → socket address. Header IPs must be globally routable (private, loopback, link-local, and multicast addresses are rejected and the next candidate is tried)
-3. The user's `roleIds` are looked up in Pangolin. For each resource in `RESOURCE_IDS`, the service checks whether the user's role is permitted on that resource and builds the list of authorized resources. **Any API failure here causes a fail-closed error — nothing is whitelisted**
+3. The user's `roleIds` and `userId` are looked up in Pangolin. For each resource in `RESOURCE_IDS`, the service checks whether the user's role is permitted on that resource **or** whether the user is directly assigned to it — mirroring Pangolin's own OR logic. **Any API failure here causes a fail-closed error — nothing is whitelisted**
 4. For each authorized resource, a Pangolin IP rule is created (if one does not already exist), and the resource's name and domain are fetched for the success-page link
 5. If CrowdSec is enabled and the IP is not already in the allowlist cache, it is added via `cscli`
 6. The response depends on the request's `Accept` header:

--- a/app.py
+++ b/app.py
@@ -108,8 +108,10 @@ def load_state():
 def save_state():
     tmp_file = STATE_FILE + ".tmp"
     try:
+        with state_lock:
+            snapshot = json.dumps(state, indent=2, sort_keys=True)
         with open(tmp_file, "w", encoding="utf-8") as f:
-            json.dump(state, f, indent=2, sort_keys=True)
+            f.write(snapshot)
         os.replace(tmp_file, STATE_FILE)
     except Exception as e:
         print(f"[state] failed to save state: {e}")
@@ -313,6 +315,9 @@ def cleanup_old_ips():
                     if rec2 and rid_str in rec2.get("resources", {}):
                         rec2["resources"].pop(rid_str, None)
                         changed = True
+                print(f"[cleanup] deleted rule for {ip} on resource {rid} (last_seen={last_seen_str})")
+            else:
+                print(f"[cleanup] delete failed for {ip} on resource {rid} — will retry next cycle")
         # If no resources remain, drop the IP record
         with state_lock:
             rec3 = state.get(ip)
@@ -332,6 +337,7 @@ def cleanup_old_ips():
                 for rid_str in expired_unowned:
                     rec4["resources"].pop(rid_str, None)
                     changed = True
+                    print(f"[cleanup] dropped unowned state entry for {ip} on resource {rid_str} (last_seen={last_seen_str})")
                 # If that emptied the record entirely, drop the IP
                 if not rec4.get("resources"):
                     state.pop(ip, None)
@@ -344,7 +350,7 @@ def cleanup_old_ips():
             print(f"[cleanup] crowdsec expire failed for {ip}: {e}")
         if changed:
             save_state()
-            print(f"[cleanup] removed {ip} (last_seen={last_seen_str})")
+            print(f"[cleanup] finished expiring {ip} (last_seen={last_seen_str})")
     print("[cleanup] done")
 
 

--- a/pangolin_connector.py
+++ b/pangolin_connector.py
@@ -9,7 +9,9 @@ from urllib.parse import quote
 
 def _retry(fn, *, attempts: int = 3, backoff: float = 1.0, label: str = ""):
     """Call fn() up to `attempts` times, sleeping backoff * 2^n between retries.
-    Only retries on Exception; propagates the final exception if all attempts fail.
+    Aborts immediately (no retry) on HTTP 401 or 403 — auth failures will not
+    resolve with retries and should surface immediately.
+    Propagates the final exception if all attempts fail.
     """
     last_exc: Exception | None = None
     for attempt in range(attempts):
@@ -17,6 +19,10 @@ def _retry(fn, *, attempts: int = 3, backoff: float = 1.0, label: str = ""):
             return fn()
         except Exception as e:
             last_exc = e
+            err_str = str(e)
+            if "HTTP 401" in err_str or "HTTP 403" in err_str:
+                print(f"[retry] {label} aborted — auth error (will not retry): {e}")
+                raise
             if attempt < attempts - 1:
                 wait = backoff * (2 ** attempt)
                 print(f"[retry] {label} attempt {attempt + 1}/{attempts} failed: {e} — retrying in {wait:.1f}s")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -685,7 +685,7 @@ def test_add_ip_to_targets_crowdsec_failure_isolated(monkeypatch, temp_state_fil
 
 
 # ---------------------------------------------------------------------------
-# Tests for removal of custom passthrough header
+# Tests for authorisation logic and passthrough header removal
 # ---------------------------------------------------------------------------
 
 def test_add_ip_to_targets_authorised_via_direct_user_assignment(monkeypatch, app_module):
@@ -765,6 +765,7 @@ def test_add_ip_to_targets_fails_closed_on_users_api_error(monkeypatch, app_modu
 
 
 
+def test_app_loads_without_custom_header_env(monkeypatch, temp_state_file):
     """App must load successfully without EXPECTED_PANGOLIN_CUSTOM_HEADER_* env vars.
     Previously these were mandatory and the module raised RuntimeError on import without them.
     """
@@ -848,3 +849,72 @@ def test_no_remote_user_fails_closed_no_ip_added(monkeypatch, temp_state_file):
         assert resources == {}, (
             f"No resources should be whitelisted when Remote-User is absent, got: {resources}"
         )
+
+# ---------------------------------------------------------------------------
+# Unit tests for _retry() auth-error abort (Item 2 — v2.2.2)
+# ---------------------------------------------------------------------------
+
+def test_retry_aborts_immediately_on_401():
+    """_retry() must not sleep or retry on HTTP 401 — raise on first attempt."""
+    import pangolin_connector
+    import time as _time
+
+    sleep_calls = []
+    original_sleep = _time.sleep
+
+    attempts = {"count": 0}
+
+    def fn():
+        attempts["count"] += 1
+        raise RuntimeError("HTTP 401 Unauthorized: invalid token")
+
+    # Patch time.sleep inside pangolin_connector to detect any retry sleep
+    original = pangolin_connector.time.sleep
+    pangolin_connector.time.sleep = lambda s: sleep_calls.append(s)
+    try:
+        try:
+            pangolin_connector._retry(fn, attempts=3, backoff=1.0, label="test-401")
+        except RuntimeError as e:
+            assert "401" in str(e)
+        else:
+            raise AssertionError("_retry should have raised")
+    finally:
+        pangolin_connector.time.sleep = original
+
+    assert attempts["count"] == 1, (
+        f"_retry must not retry on 401 — expected 1 attempt, got {attempts['count']}"
+    )
+    assert sleep_calls == [], (
+        f"_retry must not sleep on 401 — got sleep calls: {sleep_calls}"
+    )
+
+
+def test_retry_aborts_immediately_on_403():
+    """_retry() must not sleep or retry on HTTP 403 — raise on first attempt."""
+    import pangolin_connector
+
+    sleep_calls = []
+    attempts = {"count": 0}
+
+    def fn():
+        attempts["count"] += 1
+        raise RuntimeError("HTTP 403 Forbidden: key lacks permission")
+
+    original = pangolin_connector.time.sleep
+    pangolin_connector.time.sleep = lambda s: sleep_calls.append(s)
+    try:
+        try:
+            pangolin_connector._retry(fn, attempts=3, backoff=1.0, label="test-403")
+        except RuntimeError as e:
+            assert "403" in str(e)
+        else:
+            raise AssertionError("_retry should have raised")
+    finally:
+        pangolin_connector.time.sleep = original
+
+    assert attempts["count"] == 1, (
+        f"_retry must not retry on 403 — expected 1 attempt, got {attempts['count']}"
+    )
+    assert sleep_calls == [], (
+        f"_retry must not sleep on 403 — got sleep calls: {sleep_calls}"
+    )

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -764,7 +764,6 @@ def test_add_ip_to_targets_fails_closed_on_users_api_error(monkeypatch, app_modu
         assert "1.2.3.4" not in app.state
 
 
-
 def test_app_loads_without_custom_header_env(monkeypatch, temp_state_file):
     """App must load successfully without EXPECTED_PANGOLIN_CUSTOM_HEADER_* env vars.
     Previously these were mandatory and the module raised RuntimeError on import without them.
@@ -854,14 +853,13 @@ def test_no_remote_user_fails_closed_no_ip_added(monkeypatch, temp_state_file):
 # Unit tests for _retry() auth-error abort (Item 2 — v2.2.2)
 # ---------------------------------------------------------------------------
 
+
 def test_retry_aborts_immediately_on_401():
     """_retry() must not sleep or retry on HTTP 401 — raise on first attempt."""
     import pangolin_connector
     import time as _time
 
     sleep_calls = []
-    original_sleep = _time.sleep
-
     attempts = {"count": 0}
 
     def fn():
@@ -918,3 +916,336 @@ def test_retry_aborts_immediately_on_403():
     assert sleep_calls == [], (
         f"_retry must not sleep on 403 — got sleep calls: {sleep_calls}"
     )
+
+# ---------------------------------------------------------------------------
+# redact_headers_for_log — pure function, security-relevant
+# ---------------------------------------------------------------------------
+
+def test_redact_headers_authorization(app_module):
+    """Authorization header value must be replaced with <redacted>."""
+    app = app_module
+    result = app.redact_headers_for_log({"Authorization": "Bearer secret-token"})
+    assert result["Authorization"] == "<redacted>"
+
+
+def test_redact_headers_proxy_authorization(app_module):
+    """Proxy-Authorization header value must be replaced with <redacted>."""
+    app = app_module
+    result = app.redact_headers_for_log({"Proxy-Authorization": "Basic abc123"})
+    assert result["Proxy-Authorization"] == "<redacted>"
+
+
+def test_redact_headers_case_insensitive(app_module):
+    """Redaction must match header names case-insensitively."""
+    app = app_module
+    result = app.redact_headers_for_log({
+        "authorization": "Bearer lower",
+        "AUTHORIZATION": "Bearer upper",
+        "Authorization": "Bearer mixed",
+    })
+    for k in result:
+        assert result[k] == "<redacted>", f"Expected <redacted> for {k!r}, got {result[k]!r}"
+
+
+def test_redact_headers_passthrough(app_module):
+    """Non-sensitive headers must be returned unchanged."""
+    app = app_module
+    headers = {
+        "X-Real-IP": "1.2.3.4",
+        "Remote-User": "joe@example.com",
+        "Content-Type": "application/json",
+    }
+    result = app.redact_headers_for_log(headers)
+    assert result == headers
+
+
+def test_redact_headers_empty(app_module):
+    """Empty dict input must return empty dict."""
+    app = app_module
+    assert app.redact_headers_for_log({}) == {}
+
+
+def test_redact_headers_returns_copy(app_module):
+    """redact_headers_for_log must not mutate the original dict."""
+    app = app_module
+    original = {"Authorization": "Bearer secret", "X-Real-IP": "1.2.3.4"}
+    _ = app.redact_headers_for_log(original)
+    assert original["Authorization"] == "Bearer secret", "Original dict must not be mutated"
+
+
+# ---------------------------------------------------------------------------
+# save_state / load_state round-trip
+# ---------------------------------------------------------------------------
+
+def test_save_and_load_state_round_trip(monkeypatch, app_module, temp_state_file):
+    """State written by save_state must be recovered exactly by load_state."""
+    app = app_module
+    monkeypatch.setattr(app, "STATE_FILE", temp_state_file)
+
+    test_state = {
+        "1.2.3.4": {
+            "last_seen": "2025-01-01T00:00:00+00:00",
+            "resources": {"5": {"created_by_us": True}},
+        },
+        "5.6.7.8": {
+            "last_seen": "2025-06-01T12:00:00+00:00",
+            "resources": {"5": {"created_by_us": False}},
+        },
+    }
+    with app.state_lock:
+        app.state.clear()
+        app.state.update(test_state)
+
+    app.save_state()
+
+    # Clear in-memory state to prove load_state actually reads from disk
+    with app.state_lock:
+        app.state.clear()
+
+    app.load_state()
+
+    with app.state_lock:
+        assert app.state == test_state
+
+
+def test_load_state_ignores_missing_file(monkeypatch, app_module, tmp_path):
+    """load_state must not raise when the state file does not exist."""
+    app = app_module
+    monkeypatch.setattr(app, "STATE_FILE", str(tmp_path / "nonexistent.json"))
+    with app.state_lock:
+        app.state.clear()
+    app.load_state()  # must not raise
+    with app.state_lock:
+        assert app.state == {}
+
+
+def test_load_state_ignores_non_dict_content(monkeypatch, app_module, tmp_path):
+    """load_state must leave state unchanged if the file contains a non-dict."""
+    import json as _json
+    app = app_module
+    state_file = str(tmp_path / "state.json")
+    with open(state_file, "w") as f:
+        _json.dump([1, 2, 3], f)
+    monkeypatch.setattr(app, "STATE_FILE", state_file)
+    with app.state_lock:
+        app.state.clear()
+        app.state["sentinel"] = {"last_seen": "x", "resources": {}}
+    app.load_state()
+    with app.state_lock:
+        # State must be unchanged — list JSON is not a valid state dict
+        assert "sentinel" in app.state
+
+
+# ---------------------------------------------------------------------------
+# _retry — retry behaviour and exception propagation
+# ---------------------------------------------------------------------------
+
+def test_retry_retries_on_non_auth_error():
+    """_retry must attempt the function the full number of times on non-auth errors."""
+    import pangolin_connector
+
+    attempts = {"count": 0}
+    sleep_calls = []
+
+    def fn():
+        attempts["count"] += 1
+        raise RuntimeError("HTTP 500 Internal Server Error")
+
+    original = pangolin_connector.time.sleep
+    pangolin_connector.time.sleep = lambda s: sleep_calls.append(s)
+    try:
+        try:
+            pangolin_connector._retry(fn, attempts=3, backoff=1.0, label="test-500")
+        except RuntimeError:
+            pass
+    finally:
+        pangolin_connector.time.sleep = original
+
+    assert attempts["count"] == 3, (
+        f"Expected 3 attempts on non-auth error, got {attempts['count']}"
+    )
+    assert len(sleep_calls) == 2, (
+        f"Expected 2 sleep calls between 3 attempts, got {sleep_calls}"
+    )
+
+
+def test_retry_propagates_last_exception():
+    """_retry must raise the exception from the final attempt, not the first."""
+    import pangolin_connector
+
+    call_num = {"n": 0}
+
+    def fn():
+        call_num["n"] += 1
+        raise RuntimeError(f"error on attempt {call_num['n']}")
+
+    original = pangolin_connector.time.sleep
+    pangolin_connector.time.sleep = lambda s: None
+    try:
+        try:
+            pangolin_connector._retry(fn, attempts=3, backoff=0.0, label="test-last-exc")
+            raise AssertionError("_retry should have raised")
+        except RuntimeError as e:
+            assert "attempt 3" in str(e), (
+                f"Expected exception from final attempt, got: {e}"
+            )
+    finally:
+        pangolin_connector.time.sleep = original
+
+
+# ---------------------------------------------------------------------------
+# _build_cscli_cmd — pure function
+# ---------------------------------------------------------------------------
+
+def test_build_cscli_cmd_no_prefix(monkeypatch):
+    """Without a CMD_PREFIX, result must be [bin] + args."""
+    import crowdsec_connector
+    monkeypatch.setattr(crowdsec_connector, "CROWDSEC_CMD_PREFIX", "")
+    monkeypatch.setattr(crowdsec_connector, "CROWDSEC_CSCLI_BIN", "cscli")
+    result = crowdsec_connector._build_cscli_cmd(["allowlist", "list"])
+    assert result == ["cscli", "allowlist", "list"]
+
+
+def test_build_cscli_cmd_with_single_word_prefix(monkeypatch):
+    """Single-word CMD_PREFIX must be prepended as one element."""
+    import crowdsec_connector
+    monkeypatch.setattr(crowdsec_connector, "CROWDSEC_CMD_PREFIX", "sudo")
+    monkeypatch.setattr(crowdsec_connector, "CROWDSEC_CSCLI_BIN", "cscli")
+    result = crowdsec_connector._build_cscli_cmd(["allowlist", "list"])
+    assert result == ["sudo", "cscli", "allowlist", "list"]
+
+
+def test_build_cscli_cmd_with_multi_word_prefix(monkeypatch):
+    """Multi-word CMD_PREFIX must be shell-split into separate elements."""
+    import crowdsec_connector
+    monkeypatch.setattr(crowdsec_connector, "CROWDSEC_CMD_PREFIX", "docker exec crowdsec")
+    monkeypatch.setattr(crowdsec_connector, "CROWDSEC_CSCLI_BIN", "cscli")
+    result = crowdsec_connector._build_cscli_cmd(["allowlist", "add", "my-list", "1.2.3.4"])
+    assert result == ["docker", "exec", "crowdsec", "cscli", "allowlist", "add", "my-list", "1.2.3.4"]
+
+
+def test_build_cscli_cmd_custom_bin(monkeypatch):
+    """Custom CROWDSEC_CSCLI_BIN path must appear in the command."""
+    import crowdsec_connector
+    monkeypatch.setattr(crowdsec_connector, "CROWDSEC_CMD_PREFIX", "")
+    monkeypatch.setattr(crowdsec_connector, "CROWDSEC_CSCLI_BIN", "/usr/local/bin/cscli")
+    result = crowdsec_connector._build_cscli_cmd(["allowlist", "list"])
+    assert result == ["/usr/local/bin/cscli", "allowlist", "list"]
+
+
+# ---------------------------------------------------------------------------
+# _parse_crowdsec_entries_from_json — pure function, multiple input shapes
+# ---------------------------------------------------------------------------
+
+def test_parse_crowdsec_list_of_strings():
+    """Plain list of IP strings must be parsed correctly."""
+    import crowdsec_connector
+    result = crowdsec_connector._parse_crowdsec_entries_from_json(
+        '["1.2.3.4", "5.6.7.8"]'
+    )
+    assert result == {"1.2.3.4", "5.6.7.8"}
+
+
+def test_parse_crowdsec_list_of_dicts_ip_key():
+    """List of dicts with 'ip' key must extract IP values."""
+    import crowdsec_connector
+    result = crowdsec_connector._parse_crowdsec_entries_from_json(
+        '[{"ip": "1.2.3.4"}, {"ip": "5.6.7.8"}]'
+    )
+    assert result == {"1.2.3.4", "5.6.7.8"}
+
+
+def test_parse_crowdsec_list_of_dicts_value_key():
+    """List of dicts with 'value' key must extract IP values."""
+    import crowdsec_connector
+    result = crowdsec_connector._parse_crowdsec_entries_from_json(
+        '[{"value": "9.9.9.9"}]'
+    )
+    assert result == {"9.9.9.9"}
+
+
+def test_parse_crowdsec_dict_with_entries_key():
+    """Dict with 'entries' key containing IP list must be parsed."""
+    import crowdsec_connector
+    result = crowdsec_connector._parse_crowdsec_entries_from_json(
+        '{"entries": ["1.1.1.1", "2.2.2.2"]}'
+    )
+    assert result == {"1.1.1.1", "2.2.2.2"}
+
+
+def test_parse_crowdsec_dict_with_ips_key():
+    """Dict with 'ips' key must be parsed."""
+    import crowdsec_connector
+    result = crowdsec_connector._parse_crowdsec_entries_from_json(
+        '{"ips": ["3.3.3.3"]}'
+    )
+    assert result == {"3.3.3.3"}
+
+
+def test_parse_crowdsec_cidr_normalised_to_network_address():
+    """CIDR notation must be accepted and normalised to the network address."""
+    import crowdsec_connector
+    result = crowdsec_connector._parse_crowdsec_entries_from_json(
+        '["10.0.0.5/24"]'
+    )
+    assert result == {"10.0.0.0"}
+
+
+def test_parse_crowdsec_invalid_json_returns_empty():
+    """Malformed JSON must return an empty set without raising."""
+    import crowdsec_connector
+    result = crowdsec_connector._parse_crowdsec_entries_from_json("not json at all")
+    assert result == set()
+
+
+def test_parse_crowdsec_invalid_ip_skipped():
+    """Invalid IP strings in the list must be silently skipped."""
+    import crowdsec_connector
+    result = crowdsec_connector._parse_crowdsec_entries_from_json(
+        '["1.2.3.4", "not-an-ip", "5.6.7.8"]'
+    )
+    assert result == {"1.2.3.4", "5.6.7.8"}
+
+
+def test_parse_crowdsec_empty_list():
+    """Empty list must return empty set."""
+    import crowdsec_connector
+    result = crowdsec_connector._parse_crowdsec_entries_from_json("[]")
+    assert result == set()
+
+
+def test_parse_crowdsec_unknown_structure_returns_empty():
+    """Dict with no recognised key must return empty set."""
+    import crowdsec_connector
+    result = crowdsec_connector._parse_crowdsec_entries_from_json(
+        '{"unknown_key": ["1.2.3.4"]}'
+    )
+    assert result == set()
+
+
+# ---------------------------------------------------------------------------
+# cleanup_old_ips — invalid last_seen format
+# ---------------------------------------------------------------------------
+
+def test_cleanup_skips_ip_with_invalid_last_seen_format(monkeypatch, app_module):
+    """An IP with an unparseable last_seen value must be skipped, not removed."""
+    app = app_module
+    monkeypatch.setattr(app, "RETENTION_MINUTES", 0)
+
+    ip = "8.8.8.8"
+    with app.state_lock:
+        app.state[ip] = {
+            "last_seen": "not-a-valid-datetime",
+            "resources": {"5": {"created_by_us": True}},
+        }
+
+    delete_calls = []
+    monkeypatch.setattr(app, "delete_ip_rule_if_created_by_us", lambda i, r: delete_calls.append((i, r)) or True)
+    monkeypatch.setattr(app, "expire_ip_from_targets", lambda _ip: None)
+
+    app.cleanup_old_ips()
+
+    # IP must remain in state — invalid timestamp means skip, not delete
+    with app.state_lock:
+        assert ip in app.state, "IP with invalid last_seen must not be removed"
+    assert delete_calls == [], "No delete must be attempted for IP with invalid last_seen"


### PR DESCRIPTION
This release ships three internal reliability fixes and a significant expansion of the test suite. No user-facing behaviour changes or changes to docker-compose required.

- fix(app): acquire state_lock for the full json.dumps() call in save_state() to prevent a race where a concurrent thread could mutate state mid-serialisation, producing a torn write to the .tmp file

- fix(pangolin_connector): abort _retry() immediately on HTTP 401 or 403 — auth failures are permanent, retrying wastes time and masks the real error in logs

- fix(app): add per-resource detail to cleanup log output — each rule deletion logs success or failure individually, unowned state entries log when dropped, IP-level summary line updated

- fix(test): restore missing def line for test_app_loads_without_custom_header_env — orphaned code that would never run

- fix(test): remove three cosmetic flake8 violations (E303, E302, F841) introduced in prior commit

- docs: update check-in flow and Behaviour Reference to reflect direct-user assignment path added in the v2.2.1 refactor

- docs: remove stale roadmap sentence describing this release as forthcoming

- test: add 401 and 403 abort tests for _retry() — assert exactly one attempt and zero sleep calls on auth errors

- test: add non-auth retry test — asserts exactly 3 attempts and 2 sleep calls for HTTP 500

- test: add last-exception propagation test for _retry()

- test: add six tests for redact_headers_for_log — Authorization, Proxy-Authorization, case-insensitive matching, passthrough, empty input, mutation guard

- test: add save_state/load_state round-trip, missing file, and non-dict content tests

- test: add four tests for _build_cscli_cmd — no prefix, single-word prefix, multi-word docker exec prefix, custom binary path

- test: add ten tests for _parse_crowdsec_entries_from_json — all input shapes, CIDR normalisation, malformed JSON, invalid IPs, empty list, unknown structure

- test: add test_cleanup_skips_ip_with_invalid_last_seen_format — confirms ValueError branch leaves IP in state with no delete calls