### PR TITLE
Update docs: CrowdSec LAPI mode setup, config reference, migration guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,12 +24,13 @@ pangolin-ip-rule-manager/
 ├── pangolin_connector.py    # All Pangolin API interaction: PangolinContext dataclass, retry logic
 ├── crowdsec_connector.py    # CrowdSec integration via cscli subprocess
 ├── requirements.txt         # Dev dependencies (pytest, ruff) — not used in the runtime image
-├── Dockerfile               # python:3.14-alpine; includes docker-cli for CrowdSec integration
+├── Dockerfile               # python:3.14-alpine; docker-cli (Mode B) + cscli (Mode A, multi-stage from crowdsecurity/crowdsec)
 ├── docker-compose.yml       # Reference compose file — actual deployment uses Portainer
 ├── config.env.sample        # Every environment variable with inline documentation
 └── tests/
     ├── conftest.py          # sys.path setup for pytest
-    └── test_app.py          # All tests (unit + integration)
+    ├── test_app.py          # App-level unit + integration tests
+    └── test_crowdsec.py     # CrowdSec connector unit tests
 ```
 
 There is no `Makefile` and no `pyproject.toml`. The application uses Python stdlib only —
@@ -75,9 +76,14 @@ All configuration is injected at runtime via environment variables.
 |---|---|---|
 | `CROWDSEC_ENABLED` | `false` | Enable CrowdSec integration |
 | `CROWDSEC_ALLOWLIST_NAME` | `pangolin-ip-rule-manager` | Allowlist name in CrowdSec |
-| `CROWDSEC_CSCLI_BIN` | `cscli` | Path to the cscli binary |
-| `CROWDSEC_CMD_PREFIX` | _(empty)_ | Command prefix, e.g. `docker exec crowdsec` |
 | `CROWDSEC_CACHE_TTL_SECONDS` | `3600` | Cache TTL for CrowdSec allowlist membership checks |
+| **Mode A — LAPI** | | |
+| `CROWDSEC_LAPI_URL` | _(empty)_ | CrowdSec LAPI URL, e.g. `http://crowdsec:8080`. Setting this + `CROWDSEC_LAPI_LOGIN` activates LAPI mode. |
+| `CROWDSEC_LAPI_LOGIN` | _(empty)_ | Machine login from `cscli machines add` |
+| `CROWDSEC_LAPI_PASSWORD` | _(empty)_ | Machine password from `cscli machines add` |
+| **Mode B — Docker exec** | | |
+| `CROWDSEC_CMD_PREFIX` | _(empty)_ | Command prefix, e.g. `docker exec crowdsec` |
+| `CROWDSEC_CSCLI_BIN` | `cscli` | Path to the cscli binary inside the CrowdSec container |
 
 ---
 
@@ -87,12 +93,10 @@ All configuration is injected at runtime via environment variables.
 pytest
 ```
 
-Tests live in `tests/test_app.py`. `conftest.py` handles `sys.path`. All tests use
-`monkeypatch` to avoid real network calls — no live instance or credentials are needed
-to run the suite.
-
-`tests/test_crowdsec.py` does not exist yet. CrowdSec unit tests are explicitly
-deferred pending a CrowdSec refactor.
+Tests live in `tests/test_app.py` (app-level) and `tests/test_crowdsec.py` (CrowdSec
+connector). `conftest.py` handles `sys.path`. All tests use `monkeypatch` to avoid
+real subprocess or network calls — no live instance or credentials are needed to run
+the suite.
 
 ---
 
@@ -209,6 +213,19 @@ Branch protection is active on `master` (PR required, no force push, no
 deletion). A GitHub Actions workflow auto-force-resets `dev` to `master` on
 release publish. Release notes are auto-generated from PR labels per
 `.github/release.yml`.
+
+**PR labels for release notes** — each PR must carry exactly one label so the
+auto-generated release notes are accurate. Valid labels and their categories:
+
+| Label | Release notes category |
+|---|---|
+| `enhancement` / `feature` / `new` | Enhancements |
+| `bug` / `fix` | Bug Fixes |
+| `security` | Security |
+| `dependencies` / `chore` / `documentation` | Miscellaneous |
+
+One concern per PR. Bundling multiple concerns into one PR causes inaccurate
+release notes regardless of labels.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 
 This project is actively maintained and has a few things in the pipeline worth knowing about before you set it up.
 
-The CrowdSec integration is getting a security improvement that will change how the service communicates with CrowdSec. If you're planning to use that feature, it's worth knowing the setup steps will look a little different once that lands. The current approach works, but the new one will be cleaner and safer. The README will be updated when it ships.
-
 Longer term, the check-in page is getting a visual refresh to better match the Pangolin aesthetic, along with smarter resource link icons that auto-match to the app you're protecting (Jellyfin, Radarr, and so on).
 
 None of this should give you pause about installing now — the current version is stable and in production use.
@@ -162,15 +160,34 @@ services:
       # State
       STATE_FILE: /data/state.json
 
-      # CrowdSec integration
-      CROWDSEC_ENABLED: "false"
-      CROWDSEC_ALLOWLIST_NAME: pangolin-ip-rule-manager
-      CROWDSEC_CSCLI_BIN: cscli
-      CROWDSEC_CMD_PREFIX: docker exec crowdsec
-      CROWDSEC_CACHE_TTL_SECONDS: "3600"
-
       # Branding
       SITE_NAME: ""                  # shown in HTML page header/footer; leave empty to omit
+
+      # ---------------------------------------------------------------------------
+      # CrowdSec integration (optional — disabled by default)
+      # ---------------------------------------------------------------------------
+      CROWDSEC_ENABLED: "false"
+      CROWDSEC_ALLOWLIST_NAME: pangolin-ip-rule-manager
+      CROWDSEC_CACHE_TTL_SECONDS: "3600"
+
+      # --- Mode A: LAPI (recommended) ---
+      # cscli runs inside this container and authenticates to the CrowdSec LAPI
+      # over the Docker network. No Docker socket mount required.
+      #
+      # One-time setup on your CrowdSec host:
+      #   docker exec crowdsec cscli machines add pangolin-ip-rule-manager -f -
+      # Copy the printed login and password into the vars below.
+      # The container must be on the same Docker network as CrowdSec (see below).
+      CROWDSEC_LAPI_URL: ${CROWDSEC_LAPI_URL}           # e.g. http://crowdsec:8080
+      CROWDSEC_LAPI_LOGIN: ${CROWDSEC_LAPI_LOGIN}       # machine login from cscli machines add
+      CROWDSEC_LAPI_PASSWORD: ${CROWDSEC_LAPI_PASSWORD} # machine password from cscli machines add
+
+      # --- Mode B: Docker exec (legacy) ---
+      # Runs cscli inside the CrowdSec container via `docker exec`. Requires the
+      # Docker socket to be mounted (see volumes below) and docker-cli in the image.
+      # Leave these empty when using Mode A.
+      CROWDSEC_CMD_PREFIX: ""   # set to "docker exec crowdsec" for Mode B
+      CROWDSEC_CSCLI_BIN: cscli
 
       # Optional endpoints (disabled by default)
       UPDATE_ENDPOINT_ENABLED: "false"
@@ -184,13 +201,23 @@ services:
 
     volumes:
       - pangolin-ip-rule-manager-data:/data
-      # Required only for CrowdSec integration via `docker exec`. See security note below.
+      # Required for Mode B (docker exec) only. Remove or leave commented for Mode A.
       # - /var/run/docker.sock:/var/run/docker.sock:ro
+
+    networks:
+      - pangolin
 
     restart: unless-stopped
 
 volumes:
   pangolin-ip-rule-manager-data: {}
+
+networks:
+  pangolin:
+    external: true
+    # This network must include the CrowdSec container so the LAPI URL
+    # (e.g. http://crowdsec:8080) is reachable. Required for Mode A (LAPI).
+    # If your network has a different name, update both here and in CROWDSEC_LAPI_URL.
 ```
 
 Set environment variables via a `.env` file or directly in Portainer/your orchestration tool. **Never hardcode credentials.**
@@ -247,9 +274,14 @@ CrowdSec integration is disabled by default. When enabled, the service adds IPs 
 |---|---|---|---|
 | `CROWDSEC_ENABLED` | `false` | No | Set to `true` to enable CrowdSec integration. |
 | `CROWDSEC_ALLOWLIST_NAME` | `pangolin-ip-rule-manager` | No | Name of the CrowdSec allowlist to manage. Created automatically if it doesn't exist. |
-| `CROWDSEC_CSCLI_BIN` | `cscli` | No | Path or name of the `cscli` binary. |
-| `CROWDSEC_CMD_PREFIX` | _(empty)_ | No | Optional command prefix for running `cscli` in a container. Example: `docker exec crowdsec`. |
 | `CROWDSEC_CACHE_TTL_SECONDS` | `3600` | No | How long (in seconds) to cache CrowdSec allowlist membership before re-querying via `cscli`. |
+| **Mode A — LAPI (recommended)** | | | |
+| `CROWDSEC_LAPI_URL` | _(empty)_ | For Mode A | URL of the CrowdSec LAPI, e.g. `http://crowdsec:8080`. Setting this (with `CROWDSEC_LAPI_LOGIN`) activates LAPI mode. |
+| `CROWDSEC_LAPI_LOGIN` | _(empty)_ | For Mode A | Machine login from `cscli machines add`. |
+| `CROWDSEC_LAPI_PASSWORD` | _(empty)_ | For Mode A | Machine password from `cscli machines add`. |
+| **Mode B — Docker exec (legacy)** | | | |
+| `CROWDSEC_CMD_PREFIX` | _(empty)_ | For Mode B | Command prefix for running `cscli` in a container. Example: `docker exec crowdsec`. Leave empty for Mode A. |
+| `CROWDSEC_CSCLI_BIN` | `cscli` | For Mode B | Path or name of the `cscli` binary inside the CrowdSec container. |
 
 ### Optional
 
@@ -282,18 +314,59 @@ Requiring SSO on the check-in resource is what makes role-based access control p
 
 ## CrowdSec Integration
 
-CrowdSec integration is optional and disabled by default. When enabled, the service adds each checked-in IP to a named CrowdSec allowlist and removes it when the rule expires.
+CrowdSec integration is optional and disabled by default. When enabled, the service adds each checked-in IP to a named CrowdSec allowlist on check-in and removes it when the rule expires. Two modes are supported.
 
-This integration uses `cscli`. If CrowdSec runs in a container (the typical case), set `CROWDSEC_CMD_PREFIX` to `docker exec crowdsec` and mount the Docker socket read-only:
+Pangolin and CrowdSec are handled independently. If one succeeds and the other fails, the HTML success page shows the status of each integration separately. A CrowdSec failure does not roll back a successful Pangolin rule, and vice versa.
+
+### Mode A — LAPI (recommended)
+
+`cscli` is bundled inside the image and authenticates directly to the CrowdSec LAPI over the Docker network. No Docker socket mount is required.
+
+**One-time setup on your CrowdSec host:**
+
+```bash
+docker exec crowdsec cscli machines add pangolin-ip-rule-manager -f -
+```
+
+This prints a login and password. Store them securely (e.g., Bitwarden) and inject them as environment variables:
+
+```yaml
+CROWDSEC_ENABLED: "true"
+CROWDSEC_LAPI_URL: ${CROWDSEC_LAPI_URL}           # e.g. http://crowdsec:8080
+CROWDSEC_LAPI_LOGIN: ${CROWDSEC_LAPI_LOGIN}
+CROWDSEC_LAPI_PASSWORD: ${CROWDSEC_LAPI_PASSWORD}
+```
+
+The container must be on the same Docker network as your CrowdSec container. Add a `networks:` block to your compose service as shown in the [Quick Start](#docker-compose-reference) example.
+
+### Mode B — Docker exec (legacy)
+
+Runs `cscli` inside the CrowdSec container via `docker exec`. Requires mounting the Docker socket read-only and having `docker-cli` available in the image (it is).
+
+```yaml
+CROWDSEC_ENABLED: "true"
+CROWDSEC_CMD_PREFIX: "docker exec crowdsec"
+CROWDSEC_CSCLI_BIN: cscli
+```
 
 ```yaml
 volumes:
   - /var/run/docker.sock:/var/run/docker.sock:ro
 ```
 
-Pangolin and CrowdSec are handled independently. If one succeeds and the other fails, the result is reported per-target and the HTML success page shows the status of each integration separately. A CrowdSec failure does not roll back a successful Pangolin rule, and vice versa.
+> **Security note:** Docker socket access grants significant host-level capability. Mode A is recommended precisely because it avoids this requirement.
 
-> **Security note:** Docker socket access grants significant host-level capability. Ensure the container is otherwise locked down and not exposed to untrusted input.
+### Migrating from Mode B to Mode A
+
+Run the one-time setup command above to generate machine credentials, then:
+
+1. Add `CROWDSEC_LAPI_URL`, `CROWDSEC_LAPI_LOGIN`, and `CROWDSEC_LAPI_PASSWORD` to your environment
+2. Remove (or leave empty) `CROWDSEC_CMD_PREFIX`
+3. Remove the Docker socket volume mount
+4. Add the container to the same Docker network as CrowdSec
+5. Restart the container
+
+LAPI mode takes precedence automatically when `CROWDSEC_LAPI_URL` and `CROWDSEC_LAPI_LOGIN` are both set. If both sets of vars are present, a warning is logged and LAPI mode wins.
 
 ---
 
@@ -391,7 +464,7 @@ State is stored as JSON at `STATE_FILE` (default `/data/state.json`). Mount a na
 - **Header redaction in logs:** `Authorization` and `Proxy-Authorization` headers are redacted in all log output.
 - **Secrets:** All credentials should be stored in a secrets manager (e.g., Bitwarden) and injected at runtime. Never hardcode them in compose files or Dockerfiles.
 - **Scope of deletions:** The service only deletes Pangolin rules it created itself. It will never touch rules that existed before it ran.
-- **Docker socket:** If CrowdSec runs in a container, the Docker socket must be mounted read-only. Socket access grants significant host-level capability — keep the container locked down.
+- **Docker socket:** Only required for CrowdSec Mode B (docker exec). Mode A (LAPI) communicates over the Docker network and requires no socket mount. If you use Mode B, mount the socket read-only and keep the container locked down.
 
 ---
 


### PR DESCRIPTION
Updates README and CLAUDE.md to document the CrowdSec LAPI mode.

Changes:

- `README.md`: removes Roadmap CrowdSec preview (now shipped); updates Quick Start compose with Mode A/B sections and network block; extends Configuration Reference table with three LAPI vars (`CROWDSEC_LAPI_URL`, `CROWDSEC_LAPI_LOGIN`, `CROWDSEC_LAPI_PASSWORD`); rewrites CrowdSec Integration section with Mode A setup steps, Mode B steps, and a migration guide for existing users; updates Security Notes to clarify Docker socket is Mode B only

- `CLAUDE.md`: updates Dockerfile note; adds `test_crowdsec.py` to repo structure; extends CrowdSec env var table with LAPI vars; fixes Running Tests section (removes stale note about test_crowdsec.py not existing); adds PR label table to Release Flow section

**Label to apply:** `documentation`

---
_Generated by [Claude Code](https://claude.ai/code/session_011GX6fhkdkqP2PG7ZSjDFEs)_