### PR TITLE
Enable pytest and ruff checks to run automatically on PRs and pushes

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -2,10 +2,10 @@ name: Python package
 
 on:
   workflow_dispatch:
-  #push:
-#    branches: [ "master" ]
-#  pull_request:
-#    branches: [ "master" ]
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
 
 # Elevate write permissions globally so the action can create branches and PRs
 permissions:


### PR DESCRIPTION
Uncomments the `push` and `pull_request` triggers in `python-package.yml` so that ruff and pytest run automatically on every PR targeting master and every push to master.

The workflow already handles both event types correctly:

- On `pull_request`: runs ruff check (fails if violations remain) + pytest; the "Create Pull Request for Style Fixes" step is skipped by its existing `if: github.event_name != 'pull_request'` guard
- On `push` to master: runs ruff auto-fix and opens a style-fix PR if any changes were made

No logic changes — triggers only.

**Label to apply:** `chore`

---
_Generated by [Claude Code](https://claude.ai/code/session_011GX6fhkdkqP2PG7ZSjDFEs)_