### PR TITLE
Fix CrowdSec LAPI mode: add config_paths so cscli can initialise

### DIFF
--- a/crowdsec_connector.py
+++ b/crowdsec_connector.py
@@ -39,6 +39,7 @@ if _LAPI_MODE and CROWDSEC_CMD_PREFIX:
 # These are module-level constants so tests can patch them to a tmp directory.
 _LAPI_CONFIG_PATH = "/tmp/pangolin-cs-config.yaml"
 _LAPI_CREDENTIALS_PATH = "/tmp/pangolin-cs-credentials.yaml"
+_LAPI_CS_DIR = "/tmp/pangolin-cs"  # cscli requires config_paths dirs to exist
 
 # Runtime flags/caches (local to this module)
 _cache_lock = threading.Lock()
@@ -58,6 +59,8 @@ def _write_lapi_config() -> None:
     via the -c flag. The password is written only to the credentials file, never
     to the config file.
     """
+    os.makedirs(os.path.join(_LAPI_CS_DIR, "data"), exist_ok=True)
+    os.makedirs(os.path.join(_LAPI_CS_DIR, "hub"), exist_ok=True)
     credentials_fd = os.open(
         _LAPI_CREDENTIALS_PATH, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600
     )
@@ -73,6 +76,10 @@ def _write_lapi_config() -> None:
             "common:\n"
             "  log_level: warning\n"
             "  log_media: stdout\n"
+            "config_paths:\n"
+            f"  config_dir: {_LAPI_CS_DIR}\n"
+            f"  data_dir: {_LAPI_CS_DIR}/data\n"
+            f"  hub_dir: {_LAPI_CS_DIR}/hub\n"
             "api:\n"
             "  client:\n"
             "    insecure_skip_verify: false\n"

--- a/tests/test_crowdsec.py
+++ b/tests/test_crowdsec.py
@@ -708,6 +708,7 @@ def test_write_lapi_config_creates_files(monkeypatch, tmp_path):
     creds = str(tmp_path / "credentials.yaml")
     monkeypatch.setattr(crowdsec_connector, "_LAPI_CONFIG_PATH", cfg)
     monkeypatch.setattr(crowdsec_connector, "_LAPI_CREDENTIALS_PATH", creds)
+    monkeypatch.setattr(crowdsec_connector, "_LAPI_CS_DIR", str(tmp_path / "cs"))
     monkeypatch.setattr(crowdsec_connector, "CROWDSEC_LAPI_URL", "http://crowdsec:8080")
     monkeypatch.setattr(crowdsec_connector, "CROWDSEC_LAPI_LOGIN", "pangolin-test")
     monkeypatch.setattr(crowdsec_connector, "CROWDSEC_LAPI_PASSWORD", "s3cr3t")
@@ -726,6 +727,7 @@ def test_write_lapi_config_credentials_content(monkeypatch, tmp_path):
     creds = str(tmp_path / "credentials.yaml")
     monkeypatch.setattr(crowdsec_connector, "_LAPI_CONFIG_PATH", cfg)
     monkeypatch.setattr(crowdsec_connector, "_LAPI_CREDENTIALS_PATH", creds)
+    monkeypatch.setattr(crowdsec_connector, "_LAPI_CS_DIR", str(tmp_path / "cs"))
     monkeypatch.setattr(crowdsec_connector, "CROWDSEC_LAPI_URL", "http://crowdsec:8080")
     monkeypatch.setattr(crowdsec_connector, "CROWDSEC_LAPI_LOGIN", "pangolin-test")
     monkeypatch.setattr(crowdsec_connector, "CROWDSEC_LAPI_PASSWORD", "s3cr3t")
@@ -746,6 +748,7 @@ def test_write_lapi_config_password_not_in_config_file(monkeypatch, tmp_path):
     creds = str(tmp_path / "credentials.yaml")
     monkeypatch.setattr(crowdsec_connector, "_LAPI_CONFIG_PATH", cfg)
     monkeypatch.setattr(crowdsec_connector, "_LAPI_CREDENTIALS_PATH", creds)
+    monkeypatch.setattr(crowdsec_connector, "_LAPI_CS_DIR", str(tmp_path / "cs"))
     monkeypatch.setattr(crowdsec_connector, "CROWDSEC_LAPI_URL", "http://crowdsec:8080")
     monkeypatch.setattr(crowdsec_connector, "CROWDSEC_LAPI_LOGIN", "pangolin-test")
     monkeypatch.setattr(crowdsec_connector, "CROWDSEC_LAPI_PASSWORD", "s3cr3t")
@@ -764,6 +767,7 @@ def test_write_lapi_config_references_credentials_path(monkeypatch, tmp_path):
     creds = str(tmp_path / "credentials.yaml")
     monkeypatch.setattr(crowdsec_connector, "_LAPI_CONFIG_PATH", cfg)
     monkeypatch.setattr(crowdsec_connector, "_LAPI_CREDENTIALS_PATH", creds)
+    monkeypatch.setattr(crowdsec_connector, "_LAPI_CS_DIR", str(tmp_path / "cs"))
     monkeypatch.setattr(crowdsec_connector, "CROWDSEC_LAPI_URL", "http://crowdsec:8080")
     monkeypatch.setattr(crowdsec_connector, "CROWDSEC_LAPI_LOGIN", "pangolin-test")
     monkeypatch.setattr(crowdsec_connector, "CROWDSEC_LAPI_PASSWORD", "s3cr3t")
@@ -772,6 +776,31 @@ def test_write_lapi_config_references_credentials_path(monkeypatch, tmp_path):
 
     config_content = (tmp_path / "config.yaml").read_text()
     assert creds in config_content
+
+
+def test_write_lapi_config_includes_config_paths(monkeypatch, tmp_path):
+    """config.yaml includes a config_paths section so cscli can find its directories."""
+    import crowdsec_connector
+
+    cs_dir = str(tmp_path / "cs")
+    monkeypatch.setattr(
+        crowdsec_connector, "_LAPI_CONFIG_PATH", str(tmp_path / "config.yaml")
+    )
+    monkeypatch.setattr(
+        crowdsec_connector, "_LAPI_CREDENTIALS_PATH", str(tmp_path / "creds.yaml")
+    )
+    monkeypatch.setattr(crowdsec_connector, "_LAPI_CS_DIR", cs_dir)
+    monkeypatch.setattr(crowdsec_connector, "CROWDSEC_LAPI_URL", "http://crowdsec:8080")
+    monkeypatch.setattr(crowdsec_connector, "CROWDSEC_LAPI_LOGIN", "pangolin-test")
+    monkeypatch.setattr(crowdsec_connector, "CROWDSEC_LAPI_PASSWORD", "s3cr3t")
+
+    crowdsec_connector._write_lapi_config()
+
+    config_content = (tmp_path / "config.yaml").read_text()
+    assert "config_paths:" in config_content
+    assert cs_dir in config_content
+    assert (tmp_path / "cs" / "data").is_dir()
+    assert (tmp_path / "cs" / "hub").is_dir()
 
 
 def test_ensure_allowlist_calls_write_lapi_config_in_lapi_mode(monkeypatch, tmp_path):
@@ -784,6 +813,7 @@ def test_ensure_allowlist_calls_write_lapi_config_in_lapi_mode(monkeypatch, tmp_
     monkeypatch.setattr(crowdsec_connector, "_LAPI_MODE", True)
     monkeypatch.setattr(crowdsec_connector, "_LAPI_CONFIG_PATH", cfg)
     monkeypatch.setattr(crowdsec_connector, "_LAPI_CREDENTIALS_PATH", creds)
+    monkeypatch.setattr(crowdsec_connector, "_LAPI_CS_DIR", str(tmp_path / "cs"))
     monkeypatch.setattr(crowdsec_connector, "CROWDSEC_LAPI_URL", "http://crowdsec:8080")
     monkeypatch.setattr(crowdsec_connector, "CROWDSEC_LAPI_LOGIN", "pangolin-test")
     monkeypatch.setattr(crowdsec_connector, "CROWDSEC_LAPI_PASSWORD", "s3cr3t")


### PR DESCRIPTION
Fixes `Error: no configuration paths provided` on startup when CrowdSec LAPI mode is enabled.

`cscli` requires a `config_paths` section in its config file pointing to directories that exist, even when it is only making API calls. The minimal config written by `_write_lapi_config()` was missing this section.

Changes:

- `crowdsec_connector.py`: adds `_LAPI_CS_DIR = "/tmp/pangolin-cs"` constant; `_write_lapi_config()` now creates `data/` and `hub/` subdirectories under that path and includes a `config_paths` block in the generated config file

- `tests/test_crowdsec.py`: patches `_LAPI_CS_DIR` to `tmp_path` in all five tests that call `_write_lapi_config()`; adds `test_write_lapi_config_includes_config_paths` to assert the section is present and the directories are created (104 tests total, all pass)

**Label to apply:** `fix`

---
_Generated by [Claude Code](https://claude.ai/code/session_011GX6fhkdkqP2PG7ZSjDFEs)_