### PR TITLE
Fix cscli machines add command: add --auto flag, note sudo may be required

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ services:
       # over the Docker network. No Docker socket mount required.
       #
       # One-time setup on your CrowdSec host:
-      #   docker exec crowdsec cscli machines add pangolin-ip-rule-manager -f -
+      #   docker exec crowdsec cscli machines add pangolin-ip-rule-manager --auto -f -
       # Copy the printed login and password into the vars below.
       # The container must be on the same Docker network as CrowdSec (see below).
       CROWDSEC_LAPI_URL: ${CROWDSEC_LAPI_URL}           # e.g. http://crowdsec:8080
@@ -325,10 +325,12 @@ Pangolin and CrowdSec are handled independently. If one succeeds and the other f
 **One-time setup on your CrowdSec host:**
 
 ```bash
-docker exec crowdsec cscli machines add pangolin-ip-rule-manager -f -
+docker exec crowdsec cscli machines add pangolin-ip-rule-manager --auto -f -
 ```
 
-This prints a login and password. Store them securely (e.g., Bitwarden) and inject them as environment variables:
+> Depending on your Docker setup you may need to prefix with `sudo`.
+
+This prints a login and password to stdout. Store them securely (e.g., Bitwarden) and inject them as environment variables:
 
 ```yaml
 CROWDSEC_ENABLED: "true"

--- a/config.env.sample
+++ b/config.env.sample
@@ -27,7 +27,8 @@ CROWDSEC_CACHE_TTL_SECONDS=3600
 # the Docker network. No docker socket required.
 #
 # One-time setup on your CrowdSec host:
-#   docker exec crowdsec cscli machines add pangolin-ip-rule-manager -f -
+#   docker exec crowdsec cscli machines add pangolin-ip-rule-manager --auto -f -
+#   (prefix with sudo if your Docker setup requires it)
 # Copy the printed login and password into the vars below.
 # The container must be on the same Docker network as your CrowdSec container.
 CROWDSEC_LAPI_URL=http://crowdsec:8080   # required for LAPI mode

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,8 @@ services:
       # over the Docker network. No docker socket mount required.
       #
       # One-time setup on your CrowdSec host:
-      #   docker exec crowdsec cscli machines add pangolin-ip-rule-manager -f -
+      #   docker exec crowdsec cscli machines add pangolin-ip-rule-manager --auto -f -
+      #   (prefix with sudo if your Docker setup requires it)
       # Copy the printed login and password into the vars below.
       # The container must be on the same Docker network as CrowdSec (see below).
       CROWDSEC_LAPI_URL: ${CROWDSEC_LAPI_URL}       # e.g. http://crowdsec:8080 — required for LAPI mode


### PR DESCRIPTION
Fixes the one-time CrowdSec setup command documented in three places. The `--auto` flag is required (without it, `cscli machines add` errors asking for `--password` or `--auto`), and a sudo note is added for users whose Docker setup requires it.

Changes:

- `README.md`: Quick Start compose comment and Mode A setup steps both updated
- `config.env.sample`: setup comment updated
- `docker-compose.yml`: setup comment updated

**Label to apply:** `documentation`

---
_Generated by [Claude Code](https://claude.ai/code/session_011GX6fhkdkqP2PG7ZSjDFEs)_