### PR TITLE
Fix LAPI mode: set api.server.enable=true so cscli permits allowlist commands

### DIFF
--- a/crowdsec_connector.py
+++ b/crowdsec_connector.py
@@ -81,6 +81,8 @@ def _write_lapi_config() -> None:
             f"  data_dir: {_LAPI_CS_DIR}/data\n"
             f"  hub_dir: {_LAPI_CS_DIR}/hub\n"
             "api:\n"
+            "  server:\n"
+            "    enable: true\n"
             "  client:\n"
             "    insecure_skip_verify: false\n"
             f"    credentials_path: {_LAPI_CREDENTIALS_PATH}\n"

--- a/tests/test_crowdsec.py
+++ b/tests/test_crowdsec.py
@@ -801,6 +801,8 @@ def test_write_lapi_config_includes_config_paths(monkeypatch, tmp_path):
     assert cs_dir in config_content
     assert (tmp_path / "cs" / "data").is_dir()
     assert (tmp_path / "cs" / "hub").is_dir()
+    assert "api:" in config_content
+    assert "enable: true" in config_content
 
 
 def test_ensure_allowlist_calls_write_lapi_config_in_lapi_mode(monkeypatch, tmp_path):


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- cscli's `allowlist add`/`remove` commands check `api.server.enable` in the config before allowing execution, even when running remotely against a LAPI
- The config written by `_write_lapi_config()` was missing `api.server.enable: true`, causing the error: `local API is disabled -- this command must be run on the local API machine`
- Added `api.server` block with `enable: true` to the generated config
- Updated `test_write_lapi_config_includes_config_paths` to assert `enable: true` is present in the generated config

## Test plan

- [ ] All 104 existing tests pass (`pytest`)
- [ ] Rebuild dev container from updated master and verify `crowdsec allowlist add` succeeds end-to-end via LAPI

Label: `fix`

https://claude.ai/code/session_011GX6fhkdkqP2PG7ZSjDFEs
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_011GX6fhkdkqP2PG7ZSjDFEs)_