### PR TITLE
Harden CrowdSec connector: validate IP and allowlist name

### DIFF
--- a/crowdsec_connector.py
+++ b/crowdsec_connector.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import shlex
 import subprocess
 import threading
@@ -26,9 +27,29 @@ _cache_lock = threading.Lock()
 _crowdsec_allowlist_ready = False
 _crowdsec_cache = {"ts": 0.0, "ip_set": set()}
 
+# Allowlist names must be alphanumeric + hyphens/underscores, 1–63 chars.
+_ALLOWLIST_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,62}$")
+
 
 def _now_utc_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _validate_ip(ip: str) -> None:
+    """Raise ValueError if ip is not a valid IPv4 or IPv6 address."""
+    try:
+        ipaddress.ip_address(ip)
+    except ValueError:
+        raise ValueError(f"invalid IP address passed to CrowdSec connector: {ip!r}")
+
+
+def _validate_allowlist_name(name: str) -> None:
+    """Raise ValueError if name contains characters that are not safe for cscli arguments."""
+    if not name or not _ALLOWLIST_NAME_RE.match(name):
+        raise ValueError(
+            f"invalid CrowdSec allowlist name {name!r} — "
+            "use alphanumeric characters, hyphens, or underscores only (max 63 chars)"
+        )
 
 
 def _build_cscli_cmd(args: list[str]) -> list[str]:
@@ -36,7 +57,11 @@ def _build_cscli_cmd(args: list[str]) -> list[str]:
     if CROWDSEC_CMD_PREFIX:
         try:
             parts.extend(shlex.split(CROWDSEC_CMD_PREFIX))
-        except Exception:
+        except Exception as e:
+            print(
+                f"[crowdsec] WARNING: could not parse CROWDSEC_CMD_PREFIX with shlex ({e}); "
+                "treating as single token"
+            )
             parts.append(CROWDSEC_CMD_PREFIX)
     parts.append(CROWDSEC_CSCLI_BIN)
     parts.extend(args)
@@ -116,6 +141,14 @@ def crowdsec_ensure_allowlist() -> None:
         return
     if _crowdsec_allowlist_ready:
         return
+    if not CROWDSEC_CMD_PREFIX:
+        print(
+            "[crowdsec] WARNING: CROWDSEC_ENABLED=true but CROWDSEC_CMD_PREFIX is not set. "
+            "The container image does not ship cscli locally; all cscli calls will fail. "
+            "Set CROWDSEC_CMD_PREFIX='docker exec <crowdsec-container>' "
+            "or point DOCKER_HOST at a socket proxy."
+        )
+    _validate_allowlist_name(CROWDSEC_ALLOWLIST_NAME)
     exists = crowdsec_allowlist_exists(CROWDSEC_ALLOWLIST_NAME)
     if not exists:
         ok = crowdsec_create_allowlist(CROWDSEC_ALLOWLIST_NAME)
@@ -214,6 +247,7 @@ def _crowdsec_ip_known_or_refresh(ip: str) -> bool:
 def crowdsec_add_ip(ip: str) -> None:
     if not CROWDSEC_ENABLED:
         return
+    _validate_ip(ip)
     crowdsec_ensure_allowlist()
     # If we already know this IP is present, skip calling cscli add
     if _crowdsec_ip_known_or_refresh(ip):
@@ -267,6 +301,7 @@ def crowdsec_add_ip(ip: str) -> None:
 def crowdsec_remove_ip(ip: str) -> None:
     if not CROWDSEC_ENABLED:
         return
+    _validate_ip(ip)
     # Only attempt removal if we know it's present; otherwise refresh once and re-check
     present = ip in _get_crowdsec_ip_set_cached()
     if not present:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1282,6 +1282,21 @@ def test_build_cscli_cmd_custom_bin(monkeypatch):
     assert result == ["/usr/local/bin/cscli", "allowlist", "list"]
 
 
+def test_build_cscli_cmd_malformed_prefix_warns_and_falls_back(monkeypatch, capsys):
+    """Malformed prefix (unterminated quote) logs a WARNING and falls back to single token."""
+    import crowdsec_connector
+
+    monkeypatch.setattr(
+        crowdsec_connector, "CROWDSEC_CMD_PREFIX", "docker exec 'crowdsec"
+    )
+    monkeypatch.setattr(crowdsec_connector, "CROWDSEC_CSCLI_BIN", "cscli")
+    result = crowdsec_connector._build_cscli_cmd(["allowlist", "list"])
+    assert result[0] == "docker exec 'crowdsec"
+    assert result[-2:] == ["allowlist", "list"]
+    out = capsys.readouterr().out
+    assert "WARNING" in out
+
+
 # ---------------------------------------------------------------------------
 # _parse_crowdsec_entries_from_json — pure function, multiple input shapes
 # ---------------------------------------------------------------------------

--- a/tests/test_crowdsec.py
+++ b/tests/test_crowdsec.py
@@ -613,3 +613,197 @@ def test_remove_ip_all_retries_fail_no_raise(monkeypatch):
     monkeypatch.setattr(_time, "sleep", lambda s: None)
     monkeypatch.setattr(crowdsec_connector, "run_cscli", lambda args: (1, "", "error"))
     crowdsec_connector.crowdsec_remove_ip("1.2.3.4")  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# _validate_ip
+# ---------------------------------------------------------------------------
+
+
+def test_validate_ip_valid_ipv4():
+    """Valid IPv4 address passes without raising."""
+    import crowdsec_connector
+
+    crowdsec_connector._validate_ip("1.2.3.4")
+
+
+def test_validate_ip_valid_ipv6():
+    """Valid IPv6 address passes without raising."""
+    import crowdsec_connector
+
+    crowdsec_connector._validate_ip("2001:db8::1")
+
+
+def test_validate_ip_hostname_raises():
+    """Non-IP hostname raises ValueError."""
+    import crowdsec_connector
+
+    with pytest.raises(ValueError, match="invalid IP address"):
+        crowdsec_connector._validate_ip("not-an-ip")
+
+
+def test_validate_ip_flag_like_raises():
+    """Flag-like string raises ValueError — prevents flag injection via cscli arguments."""
+    import crowdsec_connector
+
+    with pytest.raises(ValueError, match="invalid IP address"):
+        crowdsec_connector._validate_ip("--output")
+
+
+def test_validate_ip_empty_raises():
+    """Empty string raises ValueError."""
+    import crowdsec_connector
+
+    with pytest.raises(ValueError):
+        crowdsec_connector._validate_ip("")
+
+
+# ---------------------------------------------------------------------------
+# _validate_allowlist_name
+# ---------------------------------------------------------------------------
+
+
+def test_validate_allowlist_name_valid():
+    """Standard alphanumeric-hyphen name passes without raising."""
+    import crowdsec_connector
+
+    crowdsec_connector._validate_allowlist_name("pangolin-ip-rule-manager")
+
+
+def test_validate_allowlist_name_underscores():
+    """Name with underscores passes without raising."""
+    import crowdsec_connector
+
+    crowdsec_connector._validate_allowlist_name("my_allowlist_1")
+
+
+def test_validate_allowlist_name_empty_raises():
+    """Empty name raises ValueError."""
+    import crowdsec_connector
+
+    with pytest.raises(ValueError, match="invalid CrowdSec allowlist name"):
+        crowdsec_connector._validate_allowlist_name("")
+
+
+def test_validate_allowlist_name_spaces_raises():
+    """Name containing spaces raises ValueError."""
+    import crowdsec_connector
+
+    with pytest.raises(ValueError, match="invalid CrowdSec allowlist name"):
+        crowdsec_connector._validate_allowlist_name("my list")
+
+
+def test_validate_allowlist_name_flag_like_raises():
+    """Name starting with '--' raises ValueError."""
+    import crowdsec_connector
+
+    with pytest.raises(ValueError, match="invalid CrowdSec allowlist name"):
+        crowdsec_connector._validate_allowlist_name("--dry-run")
+
+
+def test_validate_allowlist_name_too_long_raises():
+    """Name longer than 63 chars raises ValueError."""
+    import crowdsec_connector
+
+    with pytest.raises(ValueError, match="invalid CrowdSec allowlist name"):
+        crowdsec_connector._validate_allowlist_name("a" * 64)
+
+
+# ---------------------------------------------------------------------------
+# crowdsec_add_ip — IP validation guard
+# ---------------------------------------------------------------------------
+
+
+def test_add_ip_invalid_raises_before_subprocess(monkeypatch):
+    """Non-IP string raises ValueError before any subprocess call."""
+    import crowdsec_connector
+
+    monkeypatch.setattr(crowdsec_connector, "CROWDSEC_ENABLED", True)
+    calls = []
+    monkeypatch.setattr(
+        crowdsec_connector,
+        "run_cscli",
+        lambda args: calls.append(args) or (0, "", ""),
+    )
+    with pytest.raises(ValueError, match="invalid IP address"):
+        crowdsec_connector.crowdsec_add_ip("not-an-ip")
+    assert calls == []
+
+
+def test_add_ip_flag_like_raises_before_subprocess(monkeypatch):
+    """Flag-like string raises ValueError before any subprocess call."""
+    import crowdsec_connector
+
+    monkeypatch.setattr(crowdsec_connector, "CROWDSEC_ENABLED", True)
+    calls = []
+    monkeypatch.setattr(
+        crowdsec_connector,
+        "run_cscli",
+        lambda args: calls.append(args) or (0, "", ""),
+    )
+    with pytest.raises(ValueError, match="invalid IP address"):
+        crowdsec_connector.crowdsec_add_ip("--output")
+    assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# crowdsec_remove_ip — IP validation guard
+# ---------------------------------------------------------------------------
+
+
+def test_remove_ip_invalid_raises_before_subprocess(monkeypatch):
+    """Non-IP string raises ValueError before any subprocess call."""
+    import crowdsec_connector
+
+    monkeypatch.setattr(crowdsec_connector, "CROWDSEC_ENABLED", True)
+    calls = []
+    monkeypatch.setattr(
+        crowdsec_connector,
+        "run_cscli",
+        lambda args: calls.append(args) or (0, "", ""),
+    )
+    with pytest.raises(ValueError, match="invalid IP address"):
+        crowdsec_connector.crowdsec_remove_ip("not-an-ip")
+    assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# crowdsec_ensure_allowlist — startup warnings and name validation
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_allowlist_warns_on_empty_prefix(monkeypatch, capsys):
+    """Empty CROWDSEC_CMD_PREFIX with CrowdSec enabled prints a WARNING."""
+    import crowdsec_connector
+
+    monkeypatch.setattr(crowdsec_connector, "CROWDSEC_ENABLED", True)
+    monkeypatch.setattr(crowdsec_connector, "CROWDSEC_CMD_PREFIX", "")
+    monkeypatch.setattr(crowdsec_connector, "CROWDSEC_ALLOWLIST_NAME", "test-list")
+    monkeypatch.setattr(
+        crowdsec_connector, "crowdsec_allowlist_exists", lambda name: True
+    )
+    crowdsec_connector.crowdsec_ensure_allowlist()
+    out = capsys.readouterr().out
+    assert "WARNING" in out
+    assert "CROWDSEC_CMD_PREFIX" in out
+
+
+def test_ensure_allowlist_invalid_name_raises(monkeypatch):
+    """Invalid CROWDSEC_ALLOWLIST_NAME raises ValueError before allowlist check."""
+    import crowdsec_connector
+
+    monkeypatch.setattr(crowdsec_connector, "CROWDSEC_ENABLED", True)
+    monkeypatch.setattr(
+        crowdsec_connector, "CROWDSEC_CMD_PREFIX", "docker exec crowdsec"
+    )
+    monkeypatch.setattr(crowdsec_connector, "CROWDSEC_ALLOWLIST_NAME", "bad name!")
+    exists_calls = []
+    monkeypatch.setattr(
+        crowdsec_connector,
+        "crowdsec_allowlist_exists",
+        lambda name: exists_calls.append(name) or False,
+    )
+    with pytest.raises(ValueError, match="invalid CrowdSec allowlist name"):
+        crowdsec_connector.crowdsec_ensure_allowlist()
+    assert exists_calls == []
+    assert not crowdsec_connector._crowdsec_allowlist_ready


### PR DESCRIPTION
`Harden CrowdSec connector: validate IP and allowlist name, warn on missing cmd prefix`

- `_validate_ip()` raises `ValueError` for anything that isn't a valid IPv4/IPv6 address, including flag-like strings such as `--output`; called at the top of `crowdsec_add_ip` and `crowdsec_remove_ip` before any subprocess interaction — defense-in-depth against flag injection reaching cscli arguments

- `_validate_allowlist_name()` enforces `[a-zA-Z0-9][a-zA-Z0-9_-]{0,62}` on the configured allowlist name; called in `crowdsec_ensure_allowlist` before the allowlist existence check — raises `ValueError` and leaves `_crowdsec_allowlist_ready = False` so misconfiguration fails loudly on every call rather than silently

- `crowdsec_ensure_allowlist` now warns at startup when `CROWDSEC_CMD_PREFIX` is empty and CrowdSec is enabled; the Docker image ships `docker-cli`, not `cscli` locally, so a missing prefix means all cscli calls silently fail with file-not-found

- `_build_cscli_cmd` now logs a WARNING on `shlex.split` failure instead of silently swallowing it and falling back to a single token with no diagnostic

- 17 new tests across `tests/test_crowdsec.py` and `tests/test_app.py` covering the validation helpers, guard behaviour in `crowdsec_add_ip` and `crowdsec_remove_ip`, and the new startup warning and name validation in `crowdsec_ensure_allowlist`

---
_Generated by [Claude Code](https://claude.ai/code/session_01VgVLqFBCpkPVV5zVfkPetS)_