### PR TITLE
Add startup connectivity check for CrowdSec exec chain

### DIFF
--- a/crowdsec_connector.py
+++ b/crowdsec_connector.py
@@ -52,6 +52,19 @@ def _validate_allowlist_name(name: str) -> None:
         )
 
 
+def _crowdsec_check_connectivity() -> None:
+    """Run 'cscli version' to verify the full exec chain is reachable at startup."""
+    rc, out, err = run_cscli(["version"])
+    if rc == 0:
+        version_line = out.splitlines()[0] if out else "unknown"
+        print(f"[crowdsec] connectivity OK — {version_line}")
+    else:
+        print(
+            f"[crowdsec] WARNING: connectivity check failed (rc={rc}): "
+            f"{err or 'no output'} — check DOCKER_HOST and CROWDSEC_CMD_PREFIX"
+        )
+
+
 def _build_cscli_cmd(args: list[str]) -> list[str]:
     parts: list[str] = []
     if CROWDSEC_CMD_PREFIX:
@@ -149,6 +162,7 @@ def crowdsec_ensure_allowlist() -> None:
             "or point DOCKER_HOST at a socket proxy."
         )
     _validate_allowlist_name(CROWDSEC_ALLOWLIST_NAME)
+    _crowdsec_check_connectivity()
     exists = crowdsec_allowlist_exists(CROWDSEC_ALLOWLIST_NAME)
     if not exists:
         ok = crowdsec_create_allowlist(CROWDSEC_ALLOWLIST_NAME)

--- a/tests/test_crowdsec.py
+++ b/tests/test_crowdsec.py
@@ -239,6 +239,9 @@ def test_ensure_allowlist_already_exists(monkeypatch):
     monkeypatch.setattr(crowdsec_connector, "CROWDSEC_ENABLED", True)
     monkeypatch.setattr(crowdsec_connector, "CROWDSEC_ALLOWLIST_NAME", "test-list")
     monkeypatch.setattr(
+        crowdsec_connector, "_crowdsec_check_connectivity", lambda: None
+    )
+    monkeypatch.setattr(
         crowdsec_connector, "crowdsec_allowlist_exists", lambda name: True
     )
     created = []
@@ -259,6 +262,9 @@ def test_ensure_allowlist_creates_when_missing(monkeypatch):
     monkeypatch.setattr(crowdsec_connector, "CROWDSEC_ENABLED", True)
     monkeypatch.setattr(crowdsec_connector, "CROWDSEC_ALLOWLIST_NAME", "test-list")
     monkeypatch.setattr(
+        crowdsec_connector, "_crowdsec_check_connectivity", lambda: None
+    )
+    monkeypatch.setattr(
         crowdsec_connector, "crowdsec_allowlist_exists", lambda name: False
     )
     created = []
@@ -278,6 +284,9 @@ def test_ensure_allowlist_create_fails_warns_continues(monkeypatch, capsys):
 
     monkeypatch.setattr(crowdsec_connector, "CROWDSEC_ENABLED", True)
     monkeypatch.setattr(crowdsec_connector, "CROWDSEC_ALLOWLIST_NAME", "test-list")
+    monkeypatch.setattr(
+        crowdsec_connector, "_crowdsec_check_connectivity", lambda: None
+    )
     monkeypatch.setattr(
         crowdsec_connector, "crowdsec_allowlist_exists", lambda name: False
     )
@@ -780,6 +789,9 @@ def test_ensure_allowlist_warns_on_empty_prefix(monkeypatch, capsys):
     monkeypatch.setattr(crowdsec_connector, "CROWDSEC_CMD_PREFIX", "")
     monkeypatch.setattr(crowdsec_connector, "CROWDSEC_ALLOWLIST_NAME", "test-list")
     monkeypatch.setattr(
+        crowdsec_connector, "_crowdsec_check_connectivity", lambda: None
+    )
+    monkeypatch.setattr(
         crowdsec_connector, "crowdsec_allowlist_exists", lambda name: True
     )
     crowdsec_connector.crowdsec_ensure_allowlist()
@@ -807,3 +819,39 @@ def test_ensure_allowlist_invalid_name_raises(monkeypatch):
         crowdsec_connector.crowdsec_ensure_allowlist()
     assert exists_calls == []
     assert not crowdsec_connector._crowdsec_allowlist_ready
+
+
+# ---------------------------------------------------------------------------
+# _crowdsec_check_connectivity
+# ---------------------------------------------------------------------------
+
+
+def test_check_connectivity_success_logs_version(monkeypatch, capsys):
+    """Successful 'cscli version' logs 'connectivity OK' with the first output line."""
+    import crowdsec_connector
+
+    monkeypatch.setattr(
+        crowdsec_connector,
+        "run_cscli",
+        lambda args: (0, "v1.6.3\nextra line", ""),
+    )
+    crowdsec_connector._crowdsec_check_connectivity()
+    out = capsys.readouterr().out
+    assert "connectivity OK" in out
+    assert "v1.6.3" in out
+
+
+def test_check_connectivity_failure_logs_warning(monkeypatch, capsys):
+    """Failed 'cscli version' logs a WARNING with the error and config hints."""
+    import crowdsec_connector
+
+    monkeypatch.setattr(
+        crowdsec_connector,
+        "run_cscli",
+        lambda args: (1, "", "Cannot connect to the Docker daemon"),
+    )
+    crowdsec_connector._crowdsec_check_connectivity()
+    out = capsys.readouterr().out
+    assert "WARNING" in out
+    assert "connectivity check failed" in out
+    assert "DOCKER_HOST" in out


### PR DESCRIPTION
`Add startup connectivity check: log cscli version or warn on exec failure`

- `_crowdsec_check_connectivity()` runs `cscli version` via the configured exec chain at startup — proves the full path (socket proxy → docker exec → cscli) is reachable before any allowlist operations are attempted

- On success: logs `[crowdsec] connectivity OK — <version string>`, giving a clear confirmation in the startup logs that the socket proxy and docker exec are wired up correctly

- On failure: logs `[crowdsec] WARNING: connectivity check failed (rc=N): <error> — check DOCKER_HOST and CROWDSEC_CMD_PREFIX`, directing the operator straight to the two configuration knobs most likely to be wrong

- Non-fatal — the app continues regardless; subsequent allowlist operations will fail individually if connectivity is broken

- Called once from `crowdsec_ensure_allowlist()` after allowlist name validation, guarded by `_crowdsec_allowlist_ready` so it fires exactly once per startup

- 2 new tests for the success and failure paths; 4 existing `crowdsec_ensure_allowlist` tests updated to stub `_crowdsec_check_connectivity` as a no-op

---
_Generated by [Claude Code](https://claude.ai/code/session_01VgVLqFBCpkPVV5zVfkPetS)_