### PR TITLE
Staged startup connectivity check: isolate socket proxy, container, and cscli

### DIFF
--- a/crowdsec_connector.py
+++ b/crowdsec_connector.py
@@ -52,16 +52,84 @@ def _validate_allowlist_name(name: str) -> None:
         )
 
 
+def _run_docker_cmd(args: list[str]) -> tuple[int, str, str]:
+    """Run a docker command directly, respecting DOCKER_HOST from the environment."""
+    try:
+        proc = subprocess.run(
+            ["docker"] + args,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
+    except FileNotFoundError:
+        return 127, "", "docker not found"
+    except Exception as e:
+        return 1, "", str(e)
+
+
 def _crowdsec_check_connectivity() -> None:
-    """Run 'cscli version' to verify the full exec chain is reachable at startup."""
-    rc, out, err = run_cscli(["version"])
-    if rc == 0:
-        version_line = out.splitlines()[0] if out else "unknown"
-        print(f"[crowdsec] connectivity OK — {version_line}")
+    """Staged startup check to isolate socket-proxy, container, and cscli failures.
+
+    Stage 1 (docker exec prefix only): docker version — proves Docker API / socket proxy.
+    Stage 2 (docker exec prefix only): docker inspect <container> — proves container exists
+      and is running.
+    Stage 3 (always): cscli version via run_cscli — proves the full exec chain works.
+    Stages 1 and 2 are skipped when CROWDSEC_CMD_PREFIX is not a docker exec command.
+    All failures are warnings; the function never raises.
+    """
+    prefix_parts: list[str] = []
+    if CROWDSEC_CMD_PREFIX:
+        try:
+            prefix_parts = shlex.split(CROWDSEC_CMD_PREFIX)
+        except Exception:
+            prefix_parts = [CROWDSEC_CMD_PREFIX]
+
+    is_docker_exec = (
+        len(prefix_parts) >= 2
+        and prefix_parts[0] == "docker"
+        and "exec" in prefix_parts
+    )
+
+    if is_docker_exec:
+        # Stage 1: Docker API / socket proxy reachability
+        rc, out, err = _run_docker_cmd(["version", "--format", "{{.Server.Version}}"])
+        if rc != 0:
+            docker_host = os.environ.get("DOCKER_HOST", "(not set)")
+            print(
+                f"[crowdsec] WARNING: Docker API unreachable (rc={rc}): "
+                f"{err or 'no output'} — DOCKER_HOST={docker_host}"
+            )
+            return
+        print(f"[crowdsec] Docker API OK — server v{out}")
+
+        # Stage 2: CrowdSec container existence and running state
+        container = prefix_parts[-1]
+        rc2, out2, _ = _run_docker_cmd(
+            ["inspect", "--format", "{{.State.Running}}", container]
+        )
+        if rc2 != 0:
+            print(
+                f"[crowdsec] WARNING: container '{container}' not found — "
+                "check CROWDSEC_CMD_PREFIX"
+            )
+            return
+        if out2 != "true":
+            print(
+                f"[crowdsec] WARNING: container '{container}' exists but is not running"
+            )
+            return
+        print(f"[crowdsec] container '{container}' is running")
+
+    # Stage 3: cscli reachability via the full exec chain
+    rc3, out3, err3 = run_cscli(["version"])
+    if rc3 == 0:
+        version_line = out3.splitlines()[0] if out3 else "unknown"
+        print(f"[crowdsec] cscli OK — {version_line}")
     else:
         print(
-            f"[crowdsec] WARNING: connectivity check failed (rc={rc}): "
-            f"{err or 'no output'} — check DOCKER_HOST and CROWDSEC_CMD_PREFIX"
+            f"[crowdsec] WARNING: cscli check failed (rc={rc3}): "
+            f"{err3 or 'no output'} — check DOCKER_HOST and CROWDSEC_CMD_PREFIX"
         )
 
 

--- a/tests/test_crowdsec.py
+++ b/tests/test_crowdsec.py
@@ -822,36 +822,179 @@ def test_ensure_allowlist_invalid_name_raises(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# _crowdsec_check_connectivity
+# _crowdsec_check_connectivity — staged checks
 # ---------------------------------------------------------------------------
 
 
-def test_check_connectivity_success_logs_version(monkeypatch, capsys):
-    """Successful 'cscli version' logs 'connectivity OK' with the first output line."""
+def test_check_connectivity_full_success(monkeypatch, capsys):
+    """All three stages pass — Docker API, container running, cscli OK."""
     import crowdsec_connector
 
     monkeypatch.setattr(
-        crowdsec_connector,
-        "run_cscli",
-        lambda args: (0, "v1.6.3\nextra line", ""),
+        crowdsec_connector, "CROWDSEC_CMD_PREFIX", "docker exec crowdsec"
+    )
+
+    def fake_docker(args):
+        if args[0] == "version":
+            return 0, "26.1.3", ""
+        if args[0] == "inspect":
+            return 0, "true", ""
+        return 1, "", "unexpected"
+
+    monkeypatch.setattr(crowdsec_connector, "_run_docker_cmd", fake_docker)
+    monkeypatch.setattr(
+        crowdsec_connector, "run_cscli", lambda args: (0, "v1.6.3\nextra", "")
     )
     crowdsec_connector._crowdsec_check_connectivity()
     out = capsys.readouterr().out
-    assert "connectivity OK" in out
+    assert "Docker API OK" in out
+    assert "26.1.3" in out
+    assert "crowdsec' is running" in out
+    assert "cscli OK" in out
     assert "v1.6.3" in out
 
 
-def test_check_connectivity_failure_logs_warning(monkeypatch, capsys):
-    """Failed 'cscli version' logs a WARNING with the error and config hints."""
+def test_check_connectivity_docker_api_failure(monkeypatch, capsys):
+    """Stage 1 fails — Docker API unreachable; DOCKER_HOST shown; stages 2 and 3 skipped."""
     import crowdsec_connector
 
     monkeypatch.setattr(
+        crowdsec_connector, "CROWDSEC_CMD_PREFIX", "docker exec crowdsec"
+    )
+    monkeypatch.setenv("DOCKER_HOST", "tcp://socket-proxy:2375")
+    docker_calls = []
+    monkeypatch.setattr(
+        crowdsec_connector,
+        "_run_docker_cmd",
+        lambda args: docker_calls.append(args) or (1, "", "connection refused"),
+    )
+    cscli_calls = []
+    monkeypatch.setattr(
         crowdsec_connector,
         "run_cscli",
-        lambda args: (1, "", "Cannot connect to the Docker daemon"),
+        lambda args: cscli_calls.append(args) or (0, "", ""),
     )
     crowdsec_connector._crowdsec_check_connectivity()
     out = capsys.readouterr().out
     assert "WARNING" in out
-    assert "connectivity check failed" in out
+    assert "Docker API unreachable" in out
+    assert "tcp://socket-proxy:2375" in out
+    assert len(docker_calls) == 1  # only the version call; inspect skipped
+    assert cscli_calls == []  # stage 3 skipped after stage 1 failure
+
+
+def test_check_connectivity_container_not_found(monkeypatch, capsys):
+    """Stage 1 passes, stage 2 fails (container absent); stage 3 skipped."""
+    import crowdsec_connector
+
+    monkeypatch.setattr(
+        crowdsec_connector, "CROWDSEC_CMD_PREFIX", "docker exec crowdsec"
+    )
+
+    def fake_docker(args):
+        if args[0] == "version":
+            return 0, "26.1.3", ""
+        return 1, "", "No such container: crowdsec"
+
+    monkeypatch.setattr(crowdsec_connector, "_run_docker_cmd", fake_docker)
+    cscli_calls = []
+    monkeypatch.setattr(
+        crowdsec_connector,
+        "run_cscli",
+        lambda args: cscli_calls.append(args) or (0, "", ""),
+    )
+    crowdsec_connector._crowdsec_check_connectivity()
+    out = capsys.readouterr().out
+    assert "WARNING" in out
+    assert "not found" in out
+    assert "crowdsec" in out
+    assert cscli_calls == []
+
+
+def test_check_connectivity_container_stopped(monkeypatch, capsys):
+    """Stage 1 passes, stage 2 finds container stopped; stage 3 skipped."""
+    import crowdsec_connector
+
+    monkeypatch.setattr(
+        crowdsec_connector, "CROWDSEC_CMD_PREFIX", "docker exec crowdsec"
+    )
+
+    def fake_docker(args):
+        if args[0] == "version":
+            return 0, "26.1.3", ""
+        return 0, "false", ""  # container exists but not running
+
+    monkeypatch.setattr(crowdsec_connector, "_run_docker_cmd", fake_docker)
+    cscli_calls = []
+    monkeypatch.setattr(
+        crowdsec_connector,
+        "run_cscli",
+        lambda args: cscli_calls.append(args) or (0, "", ""),
+    )
+    crowdsec_connector._crowdsec_check_connectivity()
+    out = capsys.readouterr().out
+    assert "WARNING" in out
+    assert "not running" in out
+    assert cscli_calls == []
+
+
+def test_check_connectivity_cscli_failure(monkeypatch, capsys):
+    """Stages 1 and 2 pass; stage 3 (cscli) fails — warning names both config knobs."""
+    import crowdsec_connector
+
+    monkeypatch.setattr(
+        crowdsec_connector, "CROWDSEC_CMD_PREFIX", "docker exec crowdsec"
+    )
+
+    def fake_docker(args):
+        if args[0] == "version":
+            return 0, "26.1.3", ""
+        return 0, "true", ""
+
+    monkeypatch.setattr(crowdsec_connector, "_run_docker_cmd", fake_docker)
+    monkeypatch.setattr(
+        crowdsec_connector,
+        "run_cscli",
+        lambda args: (1, "", "cscli: not found"),
+    )
+    crowdsec_connector._crowdsec_check_connectivity()
+    out = capsys.readouterr().out
+    assert "WARNING" in out
+    assert "cscli check failed" in out
     assert "DOCKER_HOST" in out
+    assert "CROWDSEC_CMD_PREFIX" in out
+
+
+def test_check_connectivity_non_docker_prefix_success(monkeypatch, capsys):
+    """Non-docker prefix — stages 1 and 2 are skipped; only cscli is checked."""
+    import crowdsec_connector
+
+    monkeypatch.setattr(crowdsec_connector, "CROWDSEC_CMD_PREFIX", "")
+    docker_calls = []
+    monkeypatch.setattr(
+        crowdsec_connector,
+        "_run_docker_cmd",
+        lambda args: docker_calls.append(args) or (0, "", ""),
+    )
+    monkeypatch.setattr(crowdsec_connector, "run_cscli", lambda args: (0, "v1.6.3", ""))
+    crowdsec_connector._crowdsec_check_connectivity()
+    out = capsys.readouterr().out
+    assert docker_calls == []
+    assert "cscli OK" in out
+    assert "v1.6.3" in out
+
+
+def test_check_connectivity_non_docker_prefix_failure(monkeypatch, capsys):
+    """Non-docker prefix — stages 1 and 2 skipped; cscli failure logged as warning."""
+    import crowdsec_connector
+
+    monkeypatch.setattr(crowdsec_connector, "CROWDSEC_CMD_PREFIX", "")
+    monkeypatch.setattr(
+        crowdsec_connector,
+        "run_cscli",
+        lambda args: (127, "", "cscli not found"),
+    )
+    crowdsec_connector._crowdsec_check_connectivity()
+    out = capsys.readouterr().out
+    assert "WARNING" in out
+    assert "cscli check failed" in out


### PR DESCRIPTION
`Staged startup check: isolate socket proxy, container, and cscli failures`

Replaces the single-step `cscli version` check (merged in #50) with a three-stage diagnostic that pinpoints exactly which layer has failed.

- Stage 1 (docker exec prefix only): `docker version` via `_run_docker_cmd()` — proves the Docker API and socket proxy are reachable; logs `DOCKER_HOST` value in the warning so the operator sees the exact address that was tried

- Stage 2 (docker exec prefix only): `docker inspect --format {{.State.Running}} <container>` — proves the CrowdSec container exists and is running; container name is taken as the last token of `CROWDSEC_CMD_PREFIX`

- Stage 3 (always): `cscli version` via `run_cscli` — proves the full exec chain; if stages 1 and 2 have already passed, a failure here points directly at cscli inside the container

- Stages 1 and 2 are skipped when `CROWDSEC_CMD_PREFIX` is not a `docker exec` command (e.g. direct binary, sudo wrapper)

- All failures are non-fatal warnings; the app continues regardless

- 7 targeted tests replacing the 2 from #50: full success path, Docker API failure (with `DOCKER_HOST` in output), container not found, container stopped, cscli failure after docker OK, non-docker prefix success, non-docker prefix failure

---
_Generated by [Claude Code](https://claude.ai/code/session_01VgVLqFBCpkPVV5zVfkPetS)_