### PR TITLE
Add CLAUDE.md rule: verify PR is open before pushing to its branch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,16 @@ These apply to every session. Do not deviate without explicit instruction.
   chain must be validated against the test instance before going to production.
 - **Never rewrite a file unnecessarily.** Prefer targeted edits.
 
+### Before pushing to an existing branch
+
+- **Always verify the PR is still open before pushing.** Use `pull_request_read`
+  (GitHub MCP) to check `state` and `merged` before adding commits to any branch
+  that has or had a PR. If the PR is merged or closed, create a new branch from
+  the current `master` and open a fresh PR instead.
+- **Treat "Create a pull request" in push output as a red flag.** This message
+  means the branch did not previously exist on the remote — the original was
+  likely deleted after merge. Stop, check master, and open a new PR.
+
 ### Code conventions
 
 - **Python 3.14, stdlib only.** No new pip runtime dependencies.


### PR DESCRIPTION
`Add rule: always verify PR is open before pushing to its branch`

- Adds a "Before pushing to an existing branch" section to the Behavioral rules for Claude in CLAUDE.md

- Rule 1: always call `pull_request_read` (GitHub MCP) to check `state` and `merged` before adding commits to any branch that has or had a PR; if merged or closed, create a new branch from current `master` and open a fresh PR instead

- Rule 2: treat "Create a pull request" in `git push` output as a red flag — that message means the branch did not previously exist on the remote, which typically indicates it was deleted after merge

---
_Generated by [Claude Code](https://claude.ai/code/session_01VgVLqFBCpkPVV5zVfkPetS)_