### PR TITLE
Add per-IP rate limiting to cap Pangolin API fan-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ The app will **refuse to start** if `PANGOLIN_URL` or `RESOURCE_IDS` are missing
 | `CLEANUP_INTERVAL_MINUTES` | `60` | No | How frequently (in minutes) the cleanup background thread runs. |
 | `RULE_PRIORITY` | `0` | No | Priority assigned to created Pangolin IP rules. |
 | `RULES_CACHE_TTL_SECONDS` | `3600` | No | How long (in seconds) to cache Pangolin rule existence checks before re-querying. Reduces API traffic. |
+| `RATE_LIMIT_SECONDS` | `300` | No | Minimum seconds between Pangolin API fan-out calls for the same IP. Repeat check-ins within this window return a cached result without calling Pangolin. Set to `0` to disable. |
 | `STATE_FILE` | `/data/state.json` | No | Path to the persistent state file. Mount a volume at the parent directory to survive restarts. |
 
 ### CrowdSec

--- a/app.py
+++ b/app.py
@@ -36,6 +36,7 @@ CLEANUP_INTERVAL_MINUTES = int(
     os.getenv("CLEANUP_INTERVAL_MINUTES", "60")
 )  # default 1 hour in minutes
 RULE_PRIORITY = int(os.getenv("RULE_PRIORITY", "0"))
+RATE_LIMIT_SECONDS = int(os.getenv("RATE_LIMIT_SECONDS", "300"))
 RULES_CACHE_TTL_SECONDS = int(
     os.getenv("RULES_CACHE_TTL_SECONDS", "3600")
 )  # cache for existence checks (~1h)
@@ -88,6 +89,10 @@ rules_cache = {
 _crowdsec_allowlist_ready = False
 # Cache of IPs currently in the CrowdSec allowlist (with TTL)
 crowdsec_cache = {"ts": 0.0, "ip_set": set()}
+
+# Per-IP rate limit cache: {ip: (monotonic_timestamp, last_result)}
+_api_rate_limit: dict[str, tuple[float, dict]] = {}
+_api_rate_limit_lock = threading.Lock()
 
 
 def now_utc_iso() -> str:
@@ -261,6 +266,14 @@ def add_ip_to_targets(ip: str, remote_user: str = "") -> dict:
             "Ensure this resource uses SSO authentication in Pangolin."
         )
 
+    # Skip API fan-out if this IP was successfully processed recently
+    if RATE_LIMIT_SECONDS > 0:
+        with _api_rate_limit_lock:
+            entry = _api_rate_limit.get(ip)
+            if entry and (time.monotonic() - entry[0]) < RATE_LIMIT_SECONDS:
+                print(f"[targets] rate limited {ip} — returning cached result")
+                return entry[1]
+
     ctx = make_pangolin_context()
     try:
         effective_resources = pg_filter_resources_for_user(ctx, ORG_ID, remote_user)
@@ -291,6 +304,11 @@ def add_ip_to_targets(ip: str, remote_user: str = "") -> dict:
             results[key]["ok"] = False
             results[key]["detail"] = str(e)
             print(f"[targets] add failed for {ip} on {t.__class__.__name__}: {e}")
+
+    if RATE_LIMIT_SECONDS > 0 and results.get("pangolin", {}).get("ok"):
+        with _api_rate_limit_lock:
+            _api_rate_limit[ip] = (time.monotonic(), results)
+
     return results
 
 

--- a/config.env.sample
+++ b/config.env.sample
@@ -49,3 +49,4 @@ CROWDSEC_CSCLI_BIN=cscli
 # ---------------------------------------------------------------------------
 SITE_NAME=   # shown in HTML page header/footer; leave empty to omit
 UPDATE_ENDPOINT_ENABLED=false
+RATE_LIMIT_SECONDS=300  # seconds between Pangolin API fan-out calls per IP (0 to disable)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -52,6 +52,8 @@ def app_module(monkeypatch, temp_state_file):
         app.state.clear()
     with app.state_lock:
         app.rules_cache.clear()
+    with app._api_rate_limit_lock:
+        app._api_rate_limit.clear()
     return app
 
 
@@ -875,6 +877,97 @@ def test_add_ip_to_targets_fails_closed_on_users_api_error(monkeypatch, app_modu
     assert results["crowdsec"]["detail"] == "not reached"
     with app.state_lock:
         assert "1.2.3.4" not in app.state
+
+
+def test_rate_limit_skips_api_on_repeat_call(monkeypatch, app_module):
+    """Second call within RATE_LIMIT_SECONDS must return the cached result without hitting the API."""
+    app = app_module
+    monkeypatch.setattr(app, "ORG_ID", "test-org")
+    monkeypatch.setattr(app, "PANGOLIN_TOKEN", "fake-token")
+    monkeypatch.setattr(app, "RATE_LIMIT_SECONDS", 300)
+
+    api_calls = {"count": 0}
+
+    def fake_http_json(method, url, body=None):
+        api_calls["count"] += 1
+        return _standard_fake_http_json(method, url, body)
+
+    monkeypatch.setattr(app, "http_json", fake_http_json)
+
+    with app.state_lock:
+        app.state.clear()
+
+    first = app.add_ip_to_targets("1.2.3.4", remote_user="joe@example.com")
+    assert first["pangolin"]["ok"] is True
+    calls_after_first = api_calls["count"]
+    assert calls_after_first > 0
+
+    second = app.add_ip_to_targets("1.2.3.4", remote_user="joe@example.com")
+    assert second["pangolin"]["ok"] is True
+    assert api_calls["count"] == calls_after_first, (
+        "API should not be called again within the rate limit window"
+    )
+
+
+def test_rate_limit_expires_after_window(monkeypatch, app_module):
+    """A call made after the window has elapsed must hit the API again."""
+    app = app_module
+    monkeypatch.setattr(app, "ORG_ID", "test-org")
+    monkeypatch.setattr(app, "PANGOLIN_TOKEN", "fake-token")
+    monkeypatch.setattr(app, "RATE_LIMIT_SECONDS", 300)
+
+    monkeypatch.setattr(app, "http_json", _standard_fake_http_json)
+
+    with app.state_lock:
+        app.state.clear()
+
+    first = app.add_ip_to_targets("1.2.3.4", remote_user="joe@example.com")
+    assert first["pangolin"]["ok"] is True
+
+    # Back-date the cache entry so it looks expired
+    with app._api_rate_limit_lock:
+        ts, result = app._api_rate_limit["1.2.3.4"]
+        app._api_rate_limit["1.2.3.4"] = (ts - 400, result)
+
+    api_calls = {"count": 0}
+
+    def counting_http_json(method, url, body=None):
+        api_calls["count"] += 1
+        return _standard_fake_http_json(method, url, body)
+
+    monkeypatch.setattr(app, "http_json", counting_http_json)
+
+    second = app.add_ip_to_targets("1.2.3.4", remote_user="joe@example.com")
+    assert second["pangolin"]["ok"] is True
+    assert api_calls["count"] > 0, "API must be called again after the window expires"
+
+
+def test_rate_limit_zero_disables_limiting(monkeypatch, app_module):
+    """Setting RATE_LIMIT_SECONDS=0 must disable rate limiting entirely."""
+    app = app_module
+    monkeypatch.setattr(app, "ORG_ID", "test-org")
+    monkeypatch.setattr(app, "PANGOLIN_TOKEN", "fake-token")
+    monkeypatch.setattr(app, "RATE_LIMIT_SECONDS", 0)
+
+    api_calls = {"count": 0}
+
+    def counting_http_json(method, url, body=None):
+        api_calls["count"] += 1
+        return _standard_fake_http_json(method, url, body)
+
+    monkeypatch.setattr(app, "http_json", counting_http_json)
+
+    with app.state_lock:
+        app.state.clear()
+
+    app.add_ip_to_targets("1.2.3.4", remote_user="joe@example.com")
+    calls_after_first = api_calls["count"]
+    assert calls_after_first > 0
+
+    app.add_ip_to_targets("1.2.3.4", remote_user="joe@example.com")
+    assert api_calls["count"] > calls_after_first, (
+        "With RATE_LIMIT_SECONDS=0, both calls must hit the API"
+    )
 
 
 def test_app_loads_without_custom_header_env(monkeypatch, temp_state_file):


### PR DESCRIPTION
Each check-in to `/something.png` was fanning out to 3+ Pangolin API calls per configured resource with no backpressure. Since Pangolin going down takes all services offline, a misbehaving or automated client could saturate the API. This adds a per-IP cooldown so repeat requests within the window skip the fan-out and return a cached result.

- New optional env var `RATE_LIMIT_SECONDS` (default `300` — 5 minutes). Within the window, the cached success result is returned immediately without calling Pangolin.

- `last_seen` still updates on every request so the retention TTL heartbeat is unaffected.

- Set to `0` to restore the previous behaviour (no rate limiting).

- Three new unit tests cover: within-window cache hit, post-window re-call, and `RATE_LIMIT_SECONDS=0` opt-out.

- README Behaviour table and `config.env.sample` updated.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QXnj9997soH9TU1Mtic1gA)_