### PR TITLE
Format retention duration as friendly units in expiry line

### DIFF
--- a/request_handler.py
+++ b/request_handler.py
@@ -8,6 +8,16 @@ from urllib.parse import parse_qs, urlparse
 _TEMPLATE_DIR = os.path.join(os.path.dirname(__file__), "templates")
 
 
+def _format_retention(minutes: int) -> str:
+    if minutes >= 1440 and minutes % 1440 == 0:
+        days = minutes // 1440
+        return f"{days} day" if days == 1 else f"{days} days"
+    if minutes >= 60 and minutes % 60 == 0:
+        hours = minutes // 60
+        return f"{hours} hour" if hours == 1 else f"{hours} hours"
+    return f"{minutes} minute" if minutes == 1 else f"{minutes} minutes"
+
+
 def _load_template(name: str, tokens: dict[str, str]) -> str:
     with open(os.path.join(_TEMPLATE_DIR, name), encoding="utf-8") as f:
         content = f.read()
@@ -145,6 +155,7 @@ def _build_checkin_html(
             "RESOURCE_ROWS": resource_rows,
             "BOOKMARK_ROW": bookmark_row,
             "EXPIRY_STR": expires_str,
+            "RETENTION_LABEL": _format_retention(retention_minutes),
             "RETENTION_MINUTES": str(retention_minutes),
             "DETAILS_LABEL": details_label,
             "DETAILS_IP": ip,

--- a/templates/checkin.html
+++ b/templates/checkin.html
@@ -191,7 +191,7 @@
     </div>
     <p class="expiry">
       Access expires <span>{{EXPIRY_STR}}</span><br>
-      (after {{RETENTION_MINUTES}} minutes of inactivity)
+      (after {{RETENTION_LABEL}} of inactivity)
     </p>
     <button class="details-toggle" aria-expanded="false" onclick="toggleDetails('details', this)">
       {{DETAILS_LABEL}} <span class="chevron">&#9660;</span>


### PR DESCRIPTION
## What this changes

The "access expires" section previously always rendered the raw retention value in minutes, e.g.:

> (after 43200 minutes of inactivity)

This is unreadable for any retention value longer than a couple of hours. The expiry line now shows the largest clean unit:

| Config value | Old display | New display |
|---|---|---|
| `1` | 1 minutes | 1 minute |
| `60` | 60 minutes | 1 hour |
| `120` | 120 minutes | 2 hours |
| `1440` | 1440 minutes | 1 day |
| `10080` | 10080 minutes | 7 days |
| `43200` | 43200 minutes | 30 days |

The raw minute count is still shown in the "Technical details" collapsible section for precision.

## Implementation

`_format_retention(minutes: int) -> str` in `request_handler.py` — picks days if evenly divisible by 1440, hours if evenly divisible by 60, otherwise falls back to minutes. Handles singular/plural correctly. Non-clean values (e.g. 90 minutes, which is not a whole number of hours) stay in minutes.

The template (`templates/checkin.html`) token changed from `{{RETENTION_MINUTES}} minutes` to `{{RETENTION_LABEL}}` for the expiry paragraph. The `{{RETENTION_MINUTES}}` token is still used unchanged in the details section.

## Tests and lint

- 159 tests pass.
- `ruff check .` and `ruff format --check .` clean.

https://claude.ai/code/session_01FGXEJDCGaU83dffdPcChAh

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGXEJDCGaU83dffdPcChAh)_