### PR TITLE
Format retention duration as days/hours/minutes in expiry line

### DIFF
--- a/request_handler.py
+++ b/request_handler.py
@@ -8,6 +8,16 @@ from urllib.parse import parse_qs, urlparse
 _TEMPLATE_DIR = os.path.join(os.path.dirname(__file__), "templates")
 
 
+def _format_retention(minutes: int) -> str:
+    if minutes >= 1440 and minutes % 1440 == 0:
+        days = minutes // 1440
+        return f"{days} day" if days == 1 else f"{days} days"
+    if minutes >= 60 and minutes % 60 == 0:
+        hours = minutes // 60
+        return f"{hours} hour" if hours == 1 else f"{hours} hours"
+    return f"{minutes} minute" if minutes == 1 else f"{minutes} minutes"
+
+
 def _load_template(name: str, tokens: dict[str, str]) -> str:
     with open(os.path.join(_TEMPLATE_DIR, name), encoding="utf-8") as f:
         content = f.read()
@@ -145,6 +155,7 @@ def _build_checkin_html(
             "RESOURCE_ROWS": resource_rows,
             "BOOKMARK_ROW": bookmark_row,
             "EXPIRY_STR": expires_str,
+            "RETENTION_LABEL": _format_retention(retention_minutes),
             "RETENTION_MINUTES": str(retention_minutes),
             "DETAILS_LABEL": details_label,
             "DETAILS_IP": ip,

--- a/templates/checkin.html
+++ b/templates/checkin.html
@@ -191,7 +191,7 @@
     </div>
     <p class="expiry">
       Access expires <span>{{EXPIRY_STR}}</span><br>
-      (after {{RETENTION_MINUTES}} minutes of inactivity)
+      (after {{RETENTION_LABEL}} of inactivity)
     </p>
     <button class="details-toggle" aria-expanded="false" onclick="toggleDetails('details', this)">
       {{DETAILS_LABEL}} <span class="chevron">&#9660;</span>


### PR DESCRIPTION
## What this changes

The "access expires" section previously always rendered the raw retention value in minutes:

> (after 43200 minutes of inactivity)

The expiry line now shows the largest clean unit — days if evenly divisible by 1440, hours if evenly divisible by 60, otherwise minutes:

| `RETENTION_MINUTES` | Before | After |
|---|---|---|
| `1` | 1 minutes | 1 minute |
| `60` | 60 minutes | 1 hour |
| `120` | 120 minutes | 2 hours |
| `1440` | 1440 minutes | 1 day |
| `10080` | 10080 minutes | 7 days |
| `43200` | 43200 minutes | 30 days |

Non-clean values (e.g. 90 minutes, which is not a whole number of hours) stay expressed in minutes. Singular/plural handled correctly. The raw minute count is still shown unchanged in the "Technical details" collapsible section.

## Implementation

- `_format_retention(minutes: int) -> str` added to `request_handler.py`
- `RETENTION_LABEL` token added to `_build_checkin_html` token dict
- `templates/checkin.html` expiry paragraph changed from `{{RETENTION_MINUTES}} minutes` to `{{RETENTION_LABEL}}`; `{{RETENTION_MINUTES}}` remains in the details section

## Tests and lint

- 159 tests pass
- `ruff check .` and `ruff format --check .` clean

https://claude.ai/code/session_01FGXEJDCGaU83dffdPcChAh

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGXEJDCGaU83dffdPcChAh)_