### PR TITLE
Restructure check-in page layout and revert badge colours to green/red

### DIFF
--- a/request_handler.py
+++ b/request_handler.py
@@ -119,27 +119,35 @@ def _build_checkin_html(
 
     resource_rows = _render_resource_rows(resources or [], overall_ok)
 
-    bookmark_row = (
+    bookmark_html = (
         (
-            '      <button class="bookmark-btn" onclick="bookmarkPage()">\n'
-            '        <span class="access-link-left">\n'
-            '          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="flex-shrink:0;">'
+            '  <button class="bookmark-btn" onclick="bookmarkPage()">\n'
+            '    <span class="access-link-left">\n'
+            '      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="flex-shrink:0;">'
             '<path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/>'
             "</svg>\n"
-            '          <span class="access-link-text">\n'
-            '            <span class="access-link-label">Bookmark this page</span>\n'
-            '            <span class="access-link-url">Save for one-tap access next time</span>\n'
-            "          </span>\n"
-            "        </span>\n"
-            '        <svg class="access-link-arrow" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">'
+            '      <span class="access-link-text">\n'
+            '        <span class="access-link-label">Bookmark this page</span>\n'
+            '        <span class="access-link-url">Save for one-tap access next time</span>\n'
+            "      </span>\n"
+            "    </span>\n"
+            '    <svg class="access-link-arrow" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">'
             '<line x1="5" y1="12" x2="19" y2="12"/>'
             '<polyline points="12 5 19 12 12 19"/>'
             "</svg>\n"
-            "      </button>"
+            "  </button>"
         )
         if overall_ok
         else ""
     )
+
+    action_items = [x for x in [bookmark_html, resource_rows] if x]
+    if action_items:
+        actions_section = (
+            '    <div class="action-list">\n' + "\n".join(action_items) + "\n    </div>"
+        )
+    else:
+        actions_section = ""
 
     site_name_sub = f'      <div class="sub">{site_name}</div>\n' if site_name else ""
 
@@ -152,8 +160,7 @@ def _build_checkin_html(
             "IP": ip,
             "PANGOLIN_BADGE": pangolin_badge,
             "CROWDSEC_BADGE": crowdsec_badge,
-            "RESOURCE_ROWS": resource_rows,
-            "BOOKMARK_ROW": bookmark_row,
+            "ACTIONS_SECTION": actions_section,
             "EXPIRY_STR": expires_str,
             "RETENTION_LABEL": _format_retention(retention_minutes),
             "RETENTION_MINUTES": str(retention_minutes),

--- a/templates/checkin.html
+++ b/templates/checkin.html
@@ -17,6 +17,8 @@
     --accent:          oklch(0.6717 0.1946 41.93);
     --accent-dim:      oklch(0.22 0.06 41.93);
     --accent-hover-bg: oklch(0.17 0.04 41.93);
+    --status-ok:       #4ade80;
+    --status-ok-dim:   #1a3d28;
     --warn:            #fbbf24;
     --warn-dim:        #3d2e0a;
     --err:             oklch(0.5382 0.1949 22.216);
@@ -67,21 +69,22 @@
   .status-dot {
     width: 10px; height: 10px;
     border-radius: 50%;
-    background: var(--accent);
-    box-shadow: 0 0 0 3px var(--accent-dim);
+    background: var(--status-ok);
+    box-shadow: 0 0 0 3px var(--status-ok-dim);
     flex-shrink: 0;
     animation: pulse 2.4s ease-in-out infinite;
   }
   .status-dot.err { background: var(--err); box-shadow: 0 0 0 3px var(--err-dim); animation: none; }
   @keyframes pulse {
-    0%,100% { box-shadow: 0 0 0 3px var(--accent-dim); }
-    50%      { box-shadow: 0 0 0 6px var(--accent-dim); }
+    0%,100% { box-shadow: 0 0 0 3px var(--status-ok-dim); }
+    50%      { box-shadow: 0 0 0 6px var(--status-ok-dim); }
   }
   .card-header h1 { font-family: 'Space Grotesk', 'Inter', sans-serif; font-size: 15px; font-weight: 500; letter-spacing: .01em; color: var(--text); }
   .card-header .sub { font-size: 12px; color: var(--muted); margin-top: 1px; }
   .card-body { padding: 24px; }
-  .hero { font-size: 22px; font-weight: 300; line-height: 1.35; margin-bottom: 20px; color: var(--text); }
+  .hero { font-size: 22px; font-weight: 300; line-height: 1.35; margin-bottom: 16px; color: var(--text); }
   .hero strong { color: var(--accent); font-weight: 500; }
+  .action-list { display: flex; flex-direction: column; gap: 8px; margin-bottom: 20px; }
   .ip-row {
     display: flex; align-items: center; gap: 10px;
     background: var(--inner-bg); border: 1px solid var(--border-hi);
@@ -89,19 +92,11 @@
   }
   .ip-label { font-size: 11px; text-transform: uppercase; letter-spacing: .08em; color: var(--muted); flex-shrink: 0; }
   .ip-value { font-family: var(--mono); font-size: 15px; font-weight: 500; color: var(--text); letter-spacing: .02em; }
-  .status-list { display: flex; flex-direction: column; gap: 8px; margin-bottom: 20px; }
-  .status-row {
-    display: flex; align-items: center; justify-content: space-between;
-    padding: 10px 14px; border-radius: calc(var(--radius) - 2px);
-    border: 1px solid var(--border); background: var(--inner-bg);
-  }
-  .status-row .label { font-size: 13px; color: var(--muted); display: flex; align-items: center; gap: 8px; }
-  .status-row .label svg { opacity: .5; flex-shrink: 0; }
   .badge { font-family: var(--mono); font-size: 11px; font-weight: 500; padding: 3px 9px; border-radius: 4px; letter-spacing: .04em; text-transform: uppercase; }
-  .badge.ok      { background: var(--accent-dim); color: var(--accent); }
-  .badge.skip    { background: var(--border);     color: var(--muted); }
-  .badge.err     { background: var(--err-dim);    color: var(--err); }
-  .badge.warn    { background: var(--warn-dim);   color: var(--warn); }
+  .badge.ok      { background: var(--status-ok-dim); color: var(--status-ok); }
+  .badge.skip    { background: var(--border);        color: var(--muted); }
+  .badge.err     { background: var(--err-dim);       color: var(--err); }
+  .badge.warn    { background: var(--warn-dim);      color: var(--warn); }
   .access-link {
     display: flex; align-items: center; justify-content: space-between;
     padding: 10px 14px; border-radius: calc(var(--radius) - 2px);
@@ -145,15 +140,23 @@
   .details-body {
     display: none; margin-top: 8px; background: var(--inner-bg); border: 1px solid var(--border);
     border-radius: calc(var(--radius) - 2px); padding: 14px;
-    font-family: var(--mono); font-size: 12px; line-height: 1.7; color: var(--muted);
   }
   .details-body.open { display: block; animation: fadein .15s ease; }
   @keyframes fadein { from { opacity:0 } to { opacity:1 } }
-  .details-body .key { color: var(--muted); }
-  .details-body .val { color: var(--text); }
-  .details-body .ok  { color: var(--accent); }
-  .details-body .bad { color: var(--err); }
-  .details-body .row { display: flex; gap: 8px; margin-bottom: 2px; }
+  .details-status-row {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 8px 10px; border-radius: 6px; border: 1px solid var(--border);
+    background: var(--surface); margin-bottom: 6px;
+  }
+  .details-status-row .label { font-size: 13px; color: var(--muted); display: flex; align-items: center; gap: 8px; }
+  .details-status-row .label svg { opacity: .5; flex-shrink: 0; }
+  .details-divider { border: none; border-top: 1px solid var(--border); margin: 8px 0; }
+  .details-mono { font-family: var(--mono); font-size: 12px; line-height: 1.7; color: var(--muted); }
+  .details-mono .key { color: var(--muted); }
+  .details-mono .val { color: var(--text); }
+  .details-mono .ok  { color: var(--status-ok); }
+  .details-mono .bad { color: var(--err); }
+  .details-mono .row { display: flex; gap: 8px; margin-bottom: 2px; }
   .card-footer { padding: 12px 24px; border-top: 1px solid var(--border); font-size: 11px; color: var(--muted); text-align: center; letter-spacing: .02em; }
 </style>
 </head>
@@ -167,27 +170,10 @@
   </div>
   <div class="card-body">
     <p class="hero">{{HERO}}</p>
+{{ACTIONS_SECTION}}
     <div class="ip-row">
       <span class="ip-label">Your IP</span>
       <span class="ip-value">{{IP}}</span>
-    </div>
-    <div class="status-list">
-      <div class="status-row">
-        <span class="label">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
-          Pangolin access rule
-        </span>
-        {{PANGOLIN_BADGE}}
-      </div>
-      <div class="status-row">
-        <span class="label">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 8v4l3 3"/></svg>
-          CrowdSec allowlist
-        </span>
-        {{CROWDSEC_BADGE}}
-      </div>
-{{RESOURCE_ROWS}}
-{{BOOKMARK_ROW}}
     </div>
     <p class="expiry">
       Access expires <span>{{EXPIRY_STR}}</span><br>
@@ -197,12 +183,29 @@
       {{DETAILS_LABEL}} <span class="chevron">&#9660;</span>
     </button>
     <div class="details-body" id="details">
-      <div class="row"><span class="key">ip&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><span class="val">{{DETAILS_IP}}</span></div>
-      <div class="row"><span class="key">pangolin&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><span class="{{PANGOLIN_DETAIL_CLASS}}">{{PANGOLIN_DETAIL}}</span></div>
-      <div class="row"><span class="key">crowdsec&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><span class="{{CROWDSEC_DETAIL_CLASS}}">{{CROWDSEC_DETAIL}}</span></div>
-      <div class="row"><span class="key">retention&nbsp;&nbsp;&nbsp;&nbsp;</span><span class="val">{{RETENTION_MINUTES}} min</span></div>
-      <div class="row"><span class="key">expires_at&nbsp;&nbsp;&nbsp;</span><span class="val">{{EXPIRES_ISO}}</span></div>
-      <div class="row"><span class="key">last_seen&nbsp;&nbsp;&nbsp;&nbsp;</span><span class="val">{{LAST_SEEN}}</span></div>
+      <div class="details-status-row">
+        <span class="label">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+          Pangolin access rule
+        </span>
+        {{PANGOLIN_BADGE}}
+      </div>
+      <div class="details-status-row">
+        <span class="label">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 8v4l3 3"/></svg>
+          CrowdSec allowlist
+        </span>
+        {{CROWDSEC_BADGE}}
+      </div>
+      <hr class="details-divider">
+      <div class="details-mono">
+        <div class="row"><span class="key">ip&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><span class="val">{{DETAILS_IP}}</span></div>
+        <div class="row"><span class="key">pangolin&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><span class="{{PANGOLIN_DETAIL_CLASS}}">{{PANGOLIN_DETAIL}}</span></div>
+        <div class="row"><span class="key">crowdsec&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><span class="{{CROWDSEC_DETAIL_CLASS}}">{{CROWDSEC_DETAIL}}</span></div>
+        <div class="row"><span class="key">retention&nbsp;&nbsp;&nbsp;&nbsp;</span><span class="val">{{RETENTION_MINUTES}} min</span></div>
+        <div class="row"><span class="key">expires_at&nbsp;&nbsp;&nbsp;</span><span class="val">{{EXPIRES_ISO}}</span></div>
+        <div class="row"><span class="key">last_seen&nbsp;&nbsp;&nbsp;&nbsp;</span><span class="val">{{LAST_SEEN}}</span></div>
+      </div>
     </div>
   </div>
   <div class="card-footer">Requests are logged &nbsp;&middot;&nbsp; Access resets on each visit</div>


### PR DESCRIPTION
## Summary

Four layout changes to the check-in page, all in `templates/checkin.html` and `request_handler.py`:

- **Pangolin/CrowdSec status moved into the details drop-down.** The two status rows (Pangolin access rule + CrowdSec allowlist) are now inside the "Technical details" collapsible panel rather than shown permanently in the main card body. This keeps the success path clean — users who just want to know "did it work?" see only the hero message and their access links.

- **Badge colours reverted to green/red.** Added `--status-ok` (`#4ade80`) and `--status-ok-dim` (`#1a3d28`) CSS variables, independent of the Pangolin orange `--accent`. The `ok` badge is now green, `err` is red, `warn` is amber — matching conventional traffic-light semantics. The status dot in the header also pulses green on success.

- **Bookmark button moved directly under the hero.** Order is now: hero → bookmark → resource links → IP row → expiry → details toggle. Previously the bookmark appeared after the resource links, which buried it below the fold when several apps were listed.

- **Resource links follow the bookmark button.** The `ACTIONS_SECTION` token in the template wraps both the bookmark button and the resource links in a single `<div class="action-list">` that only renders when there is content (avoids phantom spacing on the failure/no-access path).

No changes to `app.py`, `pangolin_connector.py`, `crowdsec_connector.py`, or any test files. No new runtime dependencies.

## Test plan

- [ ] `pytest` — 159 tests pass
- [ ] `ruff check . && ruff format --check .` — clean
- [ ] Visual check on test container: details toggle reveals Pangolin/CrowdSec badges; main body shows bookmark then resource links; badges are green/red, not orange
- [ ] Failure path (no access granted): confirm no phantom spacing where actions would have been

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGXEJDCGaU83dffdPcChAh)_