### PR TITLE
Move IP row into details panel and remove footer reset notice

### DIFF
--- a/templates/checkin.html
+++ b/templates/checkin.html
@@ -87,8 +87,8 @@
   .action-list { display: flex; flex-direction: column; gap: 8px; margin-bottom: 20px; }
   .ip-row {
     display: flex; align-items: center; gap: 10px;
-    background: var(--inner-bg); border: 1px solid var(--border-hi);
-    border-radius: calc(var(--radius) - 2px); padding: 10px 14px; margin-bottom: 20px;
+    background: var(--surface); border: 1px solid var(--border-hi);
+    border-radius: calc(var(--radius) - 2px); padding: 10px 14px; margin-bottom: 10px;
   }
   .ip-label { font-size: 11px; text-transform: uppercase; letter-spacing: .08em; color: var(--muted); flex-shrink: 0; }
   .ip-value { font-family: var(--mono); font-size: 15px; font-weight: 500; color: var(--text); letter-spacing: .02em; }
@@ -171,10 +171,6 @@
   <div class="card-body">
     <p class="hero">{{HERO}}</p>
 {{ACTIONS_SECTION}}
-    <div class="ip-row">
-      <span class="ip-label">Your IP</span>
-      <span class="ip-value">{{IP}}</span>
-    </div>
     <p class="expiry">
       Access expires <span>{{EXPIRY_STR}}</span><br>
       (after {{RETENTION_LABEL}} of inactivity)
@@ -183,6 +179,10 @@
       {{DETAILS_LABEL}} <span class="chevron">&#9660;</span>
     </button>
     <div class="details-body" id="details">
+      <div class="ip-row">
+        <span class="ip-label">Your IP</span>
+        <span class="ip-value">{{IP}}</span>
+      </div>
       <div class="details-status-row">
         <span class="label">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
@@ -199,7 +199,6 @@
       </div>
       <hr class="details-divider">
       <div class="details-mono">
-        <div class="row"><span class="key">ip&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><span class="val">{{DETAILS_IP}}</span></div>
         <div class="row"><span class="key">pangolin&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><span class="{{PANGOLIN_DETAIL_CLASS}}">{{PANGOLIN_DETAIL}}</span></div>
         <div class="row"><span class="key">crowdsec&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><span class="{{CROWDSEC_DETAIL_CLASS}}">{{CROWDSEC_DETAIL}}</span></div>
         <div class="row"><span class="key">retention&nbsp;&nbsp;&nbsp;&nbsp;</span><span class="val">{{RETENTION_MINUTES}} min</span></div>
@@ -208,7 +207,7 @@
       </div>
     </div>
   </div>
-  <div class="card-footer">Requests are logged &nbsp;&middot;&nbsp; Access resets on each visit</div>
+  <div class="card-footer">Requests are logged</div>
 </div>
 <script>
   function toggleDetails(id, btn) {


### PR DESCRIPTION
## Summary

Two small UI tweaks to `templates/checkin.html`. No Python changes.

- **"Your IP" box moved into the Technical Details collapsible.** The styled IP row was sitting in the main card body between the action buttons and the expiry text. It's a diagnostic detail — moving it into the details panel keeps the main view focused on outcome. It now appears at the top of the panel, above the Pangolin/CrowdSec status rows, using `background: var(--surface)` so it contrasts against the `var(--inner-bg)` panel background. The redundant plain-text `ip` line that was already in the monospace section is removed.

- **Footer simplified to "Requests are logged".** "Access resets on each visit" referred to the expiry TTL restarting on every page load — technically accurate but confusing for end-users who have no need to know about that behaviour.

## Test plan

- [ ] `pytest` — 180 tests pass
- [ ] `ruff check . && ruff format --check .` — clean
- [ ] Visual: main card shows hero → bookmark/resource links → expiry → details toggle; no IP row
- [ ] Expand details: IP box at top of panel, then Pangolin/CrowdSec status rows, then monospace rows (no duplicate ip line)
- [ ] Footer reads "Requests are logged" only

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGXEJDCGaU83dffdPcChAh)_