### PR TITLE
Reword expiry line: "expires after N days" with readable date below

### DIFF
--- a/request_handler.py
+++ b/request_handler.py
@@ -75,7 +75,7 @@ def _build_checkin_html(
     try:
         seen_dt = datetime.fromisoformat(last_seen.replace("Z", "+00:00"))
         expires_dt = seen_dt + timedelta(minutes=retention_minutes)
-        expires_str = expires_dt.strftime("%Y-%m-%d %H:%M UTC")
+        expires_str = expires_dt.strftime(f"%B {expires_dt.day}, %Y at %H:%M")
         expires_iso = expires_dt.isoformat()
     except Exception:
         expires_str = "unknown"

--- a/templates/checkin.html
+++ b/templates/checkin.html
@@ -172,8 +172,8 @@
     <p class="hero">{{HERO}}</p>
 {{ACTIONS_SECTION}}
     <p class="expiry">
-      Access expires <span>{{EXPIRY_STR}}</span><br>
-      (after {{RETENTION_LABEL}} of inactivity)
+      Access expires after <span>{{RETENTION_LABEL}}</span><br>
+      ({{EXPIRY_STR}})
     </p>
     <button class="details-toggle" aria-expanded="false" onclick="toggleDetails('details', this)">
       {{DETAILS_LABEL}} <span class="chevron">&#9660;</span>


### PR DESCRIPTION
## Summary

Rewrites the expiry block on the check-in page for readability.

**Before:**
```
Access expires 2026-06-16 10:08 UTC
(after 30 days of inactivity)
```

**After:**
```
Access expires after 30 days
(June 16, 2026 at 10:08)
```

Changes:
- `request_handler.py`: date format changed from `"%Y-%m-%d %H:%M UTC"` to `f"%B {day}, %Y at %H:%M"` (uses `expires_dt.day` to avoid a zero-padded day, e.g. "June 6" not "June 06")
- `templates/checkin.html`: sentence order swapped, "of inactivity" removed, the highlighted `<span>` now wraps the retention duration rather than the ISO date

## Test plan

- [ ] `pytest` — 180 tests pass
- [ ] `ruff check . && ruff format --check .` — clean
- [ ] Visual: expiry block reads "Access expires after 30 days" / "(June 16, 2026 at 10:08)"

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGXEJDCGaU83dffdPcChAh)_