### PR TITLE
Move bookmark button below technical details panel

### DIFF
--- a/request_handler.py
+++ b/request_handler.py
@@ -141,10 +141,9 @@ def _build_checkin_html(
         else ""
     )
 
-    action_items = [x for x in [bookmark_html, resource_rows] if x]
-    if action_items:
+    if resource_rows:
         actions_section = (
-            '    <div class="action-list">\n' + "\n".join(action_items) + "\n    </div>"
+            '    <div class="action-list">\n' + resource_rows + "\n    </div>"
         )
     else:
         actions_section = ""
@@ -161,6 +160,7 @@ def _build_checkin_html(
             "PANGOLIN_BADGE": pangolin_badge,
             "CROWDSEC_BADGE": crowdsec_badge,
             "ACTIONS_SECTION": actions_section,
+            "BOOKMARK_SECTION": bookmark_html,
             "EXPIRY_STR": expires_str,
             "RETENTION_LABEL": _format_retention(retention_minutes),
             "RETENTION_MINUTES": str(retention_minutes),

--- a/templates/checkin.html
+++ b/templates/checkin.html
@@ -117,6 +117,7 @@
     border-radius: calc(var(--radius) - 2px);
     padding: 10px 14px; cursor: pointer; display: flex; align-items: center; text-align: left;
     justify-content: space-between; transition: border-color .15s, background .15s;
+    margin-top: 8px;
   }
   .bookmark-btn:hover { border-color: var(--accent); background: var(--accent-hover-bg); }
   .bookmark-btn .access-link-left { display: flex; align-items: center; gap: 8px; min-width: 0; }
@@ -206,6 +207,7 @@
         <div class="row"><span class="key">last_seen&nbsp;&nbsp;&nbsp;&nbsp;</span><span class="val">{{LAST_SEEN}}</span></div>
       </div>
     </div>
+{{BOOKMARK_SECTION}}
   </div>
   <div class="card-footer">Requests are logged</div>
 </div>


### PR DESCRIPTION
Moves the "Bookmark this page" button from the action list (above the expiry text) to below the technical details collapsible, giving it its own position at the bottom of the card body.

- `request_handler.py`: split `BOOKMARK_SECTION` out of `ACTIONS_SECTION` — resource links stay in the action list, bookmark gets its own token passed separately
- `templates/checkin.html`: add `{{BOOKMARK_SECTION}}` placeholder after the closing `</div>` of `.details-body`; add `margin-top: 8px` to `.bookmark-btn` so it sits cleanly below the details toggle/panel

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGXEJDCGaU83dffdPcChAh)_