### PR TITLE
Move expiry text to bottom of card body

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,7 @@ These apply to every session. Do not deviate without explicit instruction.
 
 ### Before pushing to an existing branch
 
+- **MANDATORY gate: call `pull_request_read` before every push to a branch associated with a PR.** No exceptions. Do this even if the PR was just opened in the same session. Check `state` and `merged`. If either shows the PR is closed or merged, stop immediately, fetch master, branch fresh, and open a new PR.
 - **Always verify the PR is still open before pushing.** Use `pull_request_read`
   (GitHub MCP) to check `state` and `merged` before adding commits to any branch
   that has or had a PR. If the PR is merged or closed, create a new branch from

--- a/templates/checkin.html
+++ b/templates/checkin.html
@@ -126,7 +126,7 @@
   .bookmark-btn .access-link-url { font-family: var(--mono); font-size: 10px; color: var(--muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
   .bookmark-btn .access-link-arrow { color: var(--accent); stroke: var(--accent); opacity: .7; flex-shrink: 0; transition: transform .15s; }
   .bookmark-btn:hover .access-link-arrow { transform: translateX(3px); opacity: 1; }
-  .expiry { font-size: 12px; color: var(--muted); text-align: center; margin-bottom: 20px; line-height: 1.5; }
+  .expiry { font-size: 12px; color: var(--muted); text-align: center; margin-top: 20px; margin-bottom: 0; line-height: 1.5; }
   .expiry span { color: var(--text); font-family: var(--mono); font-size: 12px; }
   .details-toggle {
     width: 100%; background: none; border: 1px solid var(--border);
@@ -172,10 +172,6 @@
   <div class="card-body">
     <p class="hero">{{HERO}}</p>
 {{ACTIONS_SECTION}}
-    <p class="expiry">
-      Access expires after <span>{{RETENTION_LABEL}}</span><br>
-      ({{EXPIRY_STR}})
-    </p>
     <button class="details-toggle" aria-expanded="false" onclick="toggleDetails('details', this)">
       {{DETAILS_LABEL}} <span class="chevron">&#9660;</span>
     </button>
@@ -208,6 +204,10 @@
       </div>
     </div>
 {{BOOKMARK_SECTION}}
+    <p class="expiry">
+      Access expires after <span>{{RETENTION_LABEL}}</span><br>
+      ({{EXPIRY_STR}})
+    </p>
   </div>
   <div class="card-footer">Requests are logged</div>
 </div>


### PR DESCRIPTION
Reorders the card body so the expiry notice sits at the very bottom, below the bookmark button. Final order: hero → resource links → technical details → bookmark → access expires.

- `templates/checkin.html`: move `<p class="expiry">` from above the details toggle to below `{{BOOKMARK_SECTION}}`; change `.expiry` from `margin-bottom: 20px` to `margin-top: 20px; margin-bottom: 0` to suit its new position
- `CLAUDE.md`: add mandatory gate rule — call `pull_request_read` before every push to a branch associated with a PR, no exceptions

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGXEJDCGaU83dffdPcChAh)_