### PR TITLE
Card layout option B + site_name hero text

### DIFF
--- a/request_handler.py
+++ b/request_handler.py
@@ -88,11 +88,13 @@ def _build_checkin_html(
     overall_ok = pangolin_ok
 
     dot_class = "status-dot" if overall_ok else "status-dot err"
-    hero = (
-        "Your IP address has access."
-        if overall_ok
-        else "Access may not work right now."
-    )
+    if overall_ok:
+        if site_name:
+            hero = f"Access granted to <strong>{html.escape(site_name)}</strong>."
+        else:
+            hero = "Your IP address has <strong>access</strong>."
+    else:
+        hero = "Access may not work right now."
 
     pangolin_badge = (
         '<span class="badge ok">Added</span>'
@@ -143,7 +145,8 @@ def _build_checkin_html(
 
     if resource_rows:
         actions_section = (
-            '    <div class="action-list">\n' + resource_rows + "\n    </div>"
+            '    <div class="action-list">\n' + resource_rows + "\n    </div>\n"
+            '    <hr class="section-divider">'
         )
     else:
         actions_section = ""

--- a/templates/checkin.html
+++ b/templates/checkin.html
@@ -112,12 +112,12 @@
   .access-link-url { font-family: var(--mono); font-size: 10px; color: var(--muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
   .access-link-arrow { color: var(--accent); stroke: var(--accent); opacity: .7; flex-shrink: 0; transition: transform .15s; }
   .access-link:hover .access-link-arrow { transform: translateX(3px); opacity: 1; }
+  .section-divider { border: none; border-top: 1px solid var(--border); margin: 0 0 20px; }
   .bookmark-btn {
     width: 100%; background: none; border: 1px solid var(--accent-dim);
     border-radius: calc(var(--radius) - 2px);
     padding: 10px 14px; cursor: pointer; display: flex; align-items: center; text-align: left;
     justify-content: space-between; transition: border-color .15s, background .15s;
-    margin-top: 8px;
   }
   .bookmark-btn:hover { border-color: var(--accent); background: var(--accent-hover-bg); }
   .bookmark-btn .access-link-left { display: flex; align-items: center; gap: 8px; min-width: 0; }
@@ -134,6 +134,7 @@
     color: var(--muted); font-family: var(--sans); font-size: 12px; font-weight: 400;
     padding: 9px 14px; cursor: pointer; display: flex; align-items: center;
     justify-content: space-between; transition: border-color .15s, color .15s;
+    margin-top: 8px;
   }
   .details-toggle:hover { border-color: var(--border-hi); color: var(--text); }
   .chevron { display: inline-block; transition: transform .2s; font-size: 10px; opacity: .6; }
@@ -172,6 +173,7 @@
   <div class="card-body">
     <p class="hero">{{HERO}}</p>
 {{ACTIONS_SECTION}}
+{{BOOKMARK_SECTION}}
     <button class="details-toggle" aria-expanded="false" onclick="toggleDetails('details', this)">
       {{DETAILS_LABEL}} <span class="chevron">&#9660;</span>
     </button>
@@ -203,7 +205,6 @@
         <div class="row"><span class="key">last_seen&nbsp;&nbsp;&nbsp;&nbsp;</span><span class="val">{{LAST_SEEN}}</span></div>
       </div>
     </div>
-{{BOOKMARK_SECTION}}
     <p class="expiry">
       Access expires after <span>{{RETENTION_LABEL}}</span><br>
       ({{EXPIRY_STR}})

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2091,7 +2091,7 @@ _LAST_SEEN_ISO = "2025-01-01T00:00:00+00:00"
 
 
 def test_checkin_html_success_hero_and_dot():
-    """Success path → 'has access' hero text and green (non-error) dot class."""
+    """Success path → access hero text and green (non-error) dot class."""
     from request_handler import _build_checkin_html
 
     page = _build_checkin_html(
@@ -2101,7 +2101,7 @@ def test_checkin_html_success_hero_and_dot():
         last_seen=_LAST_SEEN_ISO,
         crowdsec_enabled=False,
     )
-    assert "has access" in page
+    assert "<strong>access</strong>" in page
     assert 'class="status-dot">' in page
     assert 'class="status-dot err">' not in page
 


### PR DESCRIPTION
Implements layout option B (chosen from visual mockup) and personalises the hero text using SITE_NAME.

- `templates/checkin.html`: reorder card body to resources → [divider] → bookmark → technical details → expiry; add `.section-divider` CSS rule; move `margin-top: 8px` from `.bookmark-btn` to `.details-toggle`
- `request_handler.py`: hero text when `overall_ok` is now "Access granted to **{SITE_NAME}**." when SITE_NAME is set, or "Your IP address has **access**." when it is not; include `<hr class="section-divider">` at the end of `actions_section` when resource rows are present
- `tests/test_app.py`: update hero assertion to match new markup (`<strong>access</strong>` instead of bare `has access`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGXEJDCGaU83dffdPcChAh)_