### PR TITLE
Security & reliability hardening from code audit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -32,6 +32,7 @@ jobs:
           images: ghcr.io/joe-cole1/pangolin-ip-rule-manager
           tags: |
             type=semver,pattern={{version}}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
       - name: Build and push Docker image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v6
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Minimal Python stdlib-only image
-FROM python:3.14-alpine
+# Digest-pinned for reproducible builds; Dependabot (docker ecosystem) bumps it.
+FROM python:3.14-alpine@sha256:26730869004e2b9c4b9ad09cab8625e81d256d1ce97e72df5520e806b1709f92
 
 # Install Docker CLI for optional CrowdSec integration via 'docker exec crowdsec cscli ...'
 RUN apk add --no-cache docker-cli

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,8 @@ USER appuser
 
 EXPOSE 8080
 
+# Probe the HTTP liveness route so a hung server is detected, not just a live process.
 HEALTHCHECK --interval=60s --timeout=5s --start-period=15s --retries=3 \
-    CMD pgrep -f app.py || exit 1
+    CMD wget -q -O - "http://127.0.0.1:${LISTEN_PORT}/healthz" || exit 1
 
 CMD ["python", "/app/app.py"]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+## Supported versions
+
+Only the latest released version on `master` is supported. Please upgrade to the
+most recent release before reporting an issue.
+
+## Reporting a vulnerability
+
+Please report security vulnerabilities **privately** — do not open a public issue
+for anything security-sensitive.
+
+Use GitHub's private vulnerability reporting for this repository:
+**Security → Report a vulnerability** (the "Report a vulnerability" button on the
+repository's Security tab). This opens a private advisory visible only to the
+maintainers.
+
+When reporting, please include:
+
+- A description of the vulnerability and its impact.
+- Steps to reproduce (proof-of-concept if possible).
+- The affected version or commit.
+
+You can expect an initial acknowledgement within a few days. Because this project
+runs in a single production environment with no staging, please allow time for a
+fix to be validated before any public disclosure.
+
+## Scope notes
+
+This service gates network access to protected resources. Findings in the
+following areas are especially valued:
+
+- The request authorization chain (`Remote-User` handling, resource filtering).
+- IP extraction from forwarded headers.
+- The `/update` endpoint and any HTML rendered from user-controlled input.
+- Container/deployment configuration (Docker socket exposure, secrets handling).

--- a/STATE_BLOCK.md
+++ b/STATE_BLOCK.md
@@ -1,0 +1,40 @@
+# STATE_BLOCK — Architecture & Context Understanding
+
+One major finding/fact per line, referenced by ID from the remediation plan.
+
+## Architecture / data flow
+- A1: Entry point `app.py` — loads env config at import, builds `PangolinContext` factory, registers `TARGETS` (Pangolin always, CrowdSec optional), starts daemon cleanup thread, serves via stdlib `HTTPServer` bound to `0.0.0.0:LISTEN_PORT` (app.py:576-582).
+- A2: `request_handler.py` — factory `create_image_request_handler(ctx)` returns a `BaseHTTPRequestHandler`; routes: `/update?ip=` (opt-in), any `*.png`/`*.gif` (check-in beacon), `/` → 403, everything else → 404.
+- A3: IP extraction precedence: `X-Real-IP` → first `X-Forwarded-For` value → socket address; header values must parse and be globally routable; socket fallback unvalidated (request_handler.py:221-254).
+- A4: Authorization chain: `Remote-User` header (set by Pangolin SSO) required → `pg_filter_resources_for_user` (role match OR direct-user assignment per resource, fail-closed on any API error) → rules created only for authorised resources (app.py:246-320, pangolin_connector.py:298-331).
+- A5: `pangolin_connector.py` — all Pangolin REST calls through injected `http_json` (urllib, Bearer token, 20s timeout, HTTPS enforced at startup); `_retry` 3 attempts exp backoff, aborts immediately on 401/403.
+- A6: `crowdsec_connector.py` — shells out to `cscli` via `subprocess.run` (list args, no shell), optional `docker exec` prefix split with `shlex`; IPs validated with `ipaddress`, allowlist name regex-validated.
+- A7: State: JSON at `STATE_FILE` (`/data/state.json`), per-IP `last_seen` + `resources.{rid}.created_by_us`; chmod 600; atomic-ish write via `.tmp` + `os.replace` (app.py:118-141).
+- A8: Cleanup thread runs every `CLEANUP_INTERVAL_MINUTES`; deletes Pangolin rules only when `created_by_us: true`; retries on failure; always attempts CrowdSec expiry (app.py:337-422).
+- A9: Two TTL caches: per-resource Pangolin rule IP sets (`rules_cache`, 1h default) and CrowdSec allowlist membership; plus per-IP rate-limit result cache (`RATE_LIMIT_SECONDS`, 300s default) (app.py:84-96, 271-318).
+- A10: Runtime is Python 3.14 stdlib only; `requirements.txt` (pytest, ruff) is dev-only; 185 tests pass; `ruff check`/`format --check` clean as of this audit.
+
+## Deployment / infrastructure
+- D1: `Dockerfile` — `python:3.14-alpine` (tag-pinned, not digest-pinned), installs `docker-cli` unconditionally, non-root `appuser`, HEALTHCHECK is `pgrep -f app.py` (process-alive only, not HTTP).
+- D2: `docker-compose.yml` — pulls `ghcr.io/joe-cole1/pangolin-ip-rule-manager:latest`; cpu/mem limits set; socket-proxy pattern documented but commented out; no `cap_drop`/`no-new-privileges`/`read_only` hardening.
+- D3: `docker-publish.yml` — on release publish, buildx multi-arch push to GHCR; actions SHA-pinned; tags ONLY `type=semver,pattern={{version}}` — a `latest` tag is never produced/updated, yet compose references `:latest`.
+- D4: `docker-image.yml` — CI build on push/PR, multi-arch, no cache, image tagged `my-image-name:$(date +%s)` and discarded (build-only smoke test).
+- D5: `python-package.yml` — single job with `contents: write` + `pull-requests: write`; on push it auto-fixes with ruff and opens a PR (peter-evans/create-pull-request); on PR it checks only; pytest runs after.
+- D6: `.github/dependabot.yml` — covers `github-actions` (daily) and `docker` (weekly) only; NO `pip` ecosystem despite `requirements.txt` (git history shows past pip Dependabot PRs, so coverage regressed).
+- D7: Production runs on an Oracle VPS next to Pangolin/Traefik/CrowdSec/Portainer; no staging; Pangolin outage = all services down (per CLAUDE.md).
+
+## Key security-relevant observations (expanded in REMEDIATION_PLAN.md)
+- S1: Trust in `Remote-User`/`X-Real-IP` headers is purely topological — no shared-secret verification that requests traversed Pangolin/Traefik; a former custom-header check (`EXPECTED_PANGOLIN_CUSTOM_HEADER_*`) was removed (tests/test_app.py:976-1024 document the removal).
+- S2: `_build_checkin_html` interpolates `PANGOLIN_DETAIL`/`CROWDSEC_DETAIL` (exception text, includes `Remote-User` and upstream API response bodies) into HTML without `html.escape` (request_handler.py:174-176); `site_name` unescaped in `SITE_NAME_SUB` (request_handler.py:155, 184).
+- S3: Server is single-threaded `HTTPServer` with blocking upstream calls (3 retries × 20s timeouts) — one slow request/upstream stalls all traffic (app.py:577).
+- S4: Rate-limit result cache is keyed by IP only, and failure results are cached too (app.py:271-277, 310-318).
+- S5: `delete_ip_rule_if_created_by_us` never invalidates `rules_cache` after deleting a rule (pangolin_connector.py:147-190).
+- S6: `save_state` uses a single shared `.tmp` path; cleanup thread and request handling can race the temp file (app.py:131-141).
+- S7: `last_seen` is stamped and persisted to disk before authorization on both the beacon and `/update` paths (documented intentional; still a per-request disk write from unauthenticated traffic) (request_handler.py:341-347, 429-436).
+- S8: `redact_headers_for_log` exists and is injected into the handler context but is never called in the request path (app.py:103-115, 441).
+- S9: Templates `@import` Google Fonts (external fetch, user-IP disclosure to Google); no Content-Security-Policy header (templates/checkin.html:8, templates/error.html:8; request_handler.py:260-262).
+- S10: `crowdsec_allowlist_exists` plain-text fallback uses substring match (`name in out3`) — false positive for prefix names (crowdsec_connector.py:194-198).
+- S11: CrowdSec CIDR entries normalised to network address only — membership checks for IPs inside a CIDR miss (crowdsec_connector.py:261-285).
+- S12: Duplicated module-level CrowdSec globals in app.py (`_crowdsec_allowlist_ready`, `crowdsec_cache`, CROWDSEC_* env parsing) shadow crowdsec_connector's own — dead/drift-prone (app.py:44-59, 89-92).
+- S13: `Target` polymorphism defeated by `isinstance` checks and divergent `add_ip` signature (app.py:296-302, 184-198).
+- S14: No LICENSE, no SECURITY.md, no pyproject.toml (ruff runs on defaults).

--- a/app.py
+++ b/app.py
@@ -96,10 +96,8 @@ rules_cache = {
     # rid: {"ts": epoch_seconds, "ip_set": set([...])}
 }
 
-# CrowdSec runtime flags/caches
-_crowdsec_allowlist_ready = False
-# Cache of IPs currently in the CrowdSec allowlist (with TTL)
-crowdsec_cache = {"ts": 0.0, "ip_set": set()}
+# CrowdSec allowlist readiness/caches live in crowdsec_connector; app.py does not
+# duplicate them.
 
 # Per-IP rate limit cache: {ip: (monotonic_timestamp, last_result)}
 _api_rate_limit: dict[str, tuple[float, dict]] = {}

--- a/app.py
+++ b/app.py
@@ -184,12 +184,15 @@ def http_json(method: str, url: str, body: dict | None = None) -> dict:
         raise RuntimeError(f"Network error: {e}")
 
 
-# Targets common interface
+# Targets common interface. All targets share one add_ip signature so the caller can
+# dispatch uniformly without type checks; targets ignore resource_ids they don't use.
 class Target:
+    name = "target"
+
     def ensure_ready(self) -> None:
         pass
 
-    def add_ip(self, ip: str) -> None:
+    def add_ip(self, ip: str, resource_ids: list[int] | None = None) -> None:
         raise NotImplementedError
 
     def expire_ip(self, ip: str) -> None:
@@ -197,6 +200,8 @@ class Target:
 
 
 class PangolinTarget(Target):
+    name = "pangolin"
+
     def __init__(self, ctx_factory):
         self._ctx_factory = ctx_factory
 
@@ -214,10 +219,12 @@ class PangolinTarget(Target):
 
 
 class CrowdSecTarget(Target):
+    name = "crowdsec"
+
     def ensure_ready(self) -> None:
         crowdsec_ensure_allowlist()
 
-    def add_ip(self, ip: str) -> None:
+    def add_ip(self, ip: str, resource_ids: list[int] | None = None) -> None:
         crowdsec_add_ip(ip)
 
     def expire_ip(self, ip: str) -> None:
@@ -309,12 +316,9 @@ def add_ip_to_targets(ip: str, remote_user: str = "") -> dict:
         "resources": effective_resources,
     }
     for t in TARGETS:
-        key = "crowdsec" if isinstance(t, CrowdSecTarget) else "pangolin"
+        key = t.name
         try:
-            if isinstance(t, PangolinTarget):
-                t.add_ip(ip, resource_ids=effective_ids)
-            else:
-                t.add_ip(ip)
+            t.add_ip(ip, resource_ids=effective_ids)
             results[key]["ok"] = True
             results[key]["detail"] = "ok"
         except Exception as e:

--- a/app.py
+++ b/app.py
@@ -63,6 +63,11 @@ SITE_NAME = os.getenv("SITE_NAME", "").strip()
 UPDATE_ENDPOINT_ENABLED = os.getenv(
     "UPDATE_ENDPOINT_ENABLED", "false"
 ).strip().lower() in ("1", "true", "yes", "on")
+# Optional: defense-in-depth shared secret that the upstream proxy (Pangolin/Traefik)
+# must inject as the X-Proxy-Secret header. When set, requests missing or mismatching
+# the secret are rejected before any state write or API call. Leave empty to disable
+# (the service then relies solely on network topology to keep it behind the proxy).
+PROXY_SHARED_SECRET = os.getenv("PROXY_SHARED_SECRET", "")
 
 # Minimal 1x1 PNG (transparent) as bytes
 BANNER_PNG = base64.b64decode(
@@ -431,6 +436,7 @@ def _make_image_handler_context() -> dict:
         "retention_minutes": RETENTION_MINUTES,
         "crowdsec_enabled": CROWDSEC_ENABLED,
         "site_name": SITE_NAME,
+        "proxy_shared_secret": PROXY_SHARED_SECRET,
         "state": state,
         "state_lock": state_lock,
         "now_utc_iso": now_utc_iso,
@@ -490,6 +496,12 @@ def self_check():
         print("")
     if not ORG_ID:
         print("[warn] ORG_ID is not set; startup resource listing will be skipped.")
+    if not PROXY_SHARED_SECRET:
+        print(
+            "[warn] PROXY_SHARED_SECRET is not set; the service relies solely on network "
+            "topology to stay behind the proxy. Set it and have Pangolin/Traefik inject "
+            "the X-Proxy-Secret header for defense-in-depth."
+        )
 
     # Verify state file directory is writable before we need it
     state_dir = os.path.dirname(os.path.abspath(STATE_FILE))

--- a/app.py
+++ b/app.py
@@ -70,6 +70,13 @@ UPDATE_ENDPOINT_ENABLED = os.getenv(
 # the secret are rejected before any state write or API call. Leave empty to disable
 # (the service then relies solely on network topology to keep it behind the proxy).
 PROXY_SHARED_SECRET = os.getenv("PROXY_SHARED_SECRET", "")
+# Optional: log all request headers (with Authorization redacted) for debugging.
+DEBUG_LOG_HEADERS = os.getenv("DEBUG_LOG_HEADERS", "false").strip().lower() in (
+    "1",
+    "true",
+    "yes",
+    "on",
+)
 
 # Minimal 1x1 PNG (transparent) as bytes
 BANNER_PNG = base64.b64decode(
@@ -451,6 +458,7 @@ def _make_image_handler_context() -> dict:
         "crowdsec_enabled": CROWDSEC_ENABLED,
         "site_name": SITE_NAME,
         "proxy_shared_secret": PROXY_SHARED_SECRET,
+        "debug_log_headers": DEBUG_LOG_HEADERS,
         "state": state,
         "state_lock": state_lock,
         "now_utc_iso": now_utc_iso,

--- a/app.py
+++ b/app.py
@@ -1,10 +1,12 @@
 import base64
+import contextlib
 import json
 import os
+import tempfile
 import threading
 import time
 from datetime import datetime, timedelta, timezone
-from http.server import HTTPServer
+from http.server import ThreadingHTTPServer
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 from urllib.error import HTTPError, URLError
@@ -79,6 +81,9 @@ BANNER_GIF = base64.b64decode(
 )
 
 state_lock = threading.Lock()
+# Serializes save_state() so concurrent writers (request threads + cleanup thread)
+# cannot race on the temporary file or clobber each other's os.replace.
+_save_lock = threading.Lock()
 state = {
     # ip: {
     #   "last_seen": "2025-01-01T00:00:00Z",
@@ -134,16 +139,23 @@ def load_state():
 
 
 def save_state():
-    tmp_file = STATE_FILE + ".tmp"
-    try:
+    with _save_lock:
         with state_lock:
             snapshot = json.dumps(state, indent=2, sort_keys=True)
-        with open(tmp_file, "w", encoding="utf-8") as f:
-            f.write(snapshot)
-        os.replace(tmp_file, STATE_FILE)
-        os.chmod(STATE_FILE, 0o600)
-    except Exception as e:
-        print(f"[state] failed to save state: {e}")
+        state_dir = os.path.dirname(os.path.abspath(STATE_FILE))
+        tmp_file = None
+        try:
+            fd, tmp_file = tempfile.mkstemp(dir=state_dir, suffix=".tmp")
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(snapshot)
+            os.replace(tmp_file, STATE_FILE)
+            tmp_file = None
+            os.chmod(STATE_FILE, 0o600)
+        except Exception as e:
+            print(f"[state] failed to save state: {e}")
+            if tmp_file is not None:
+                with contextlib.suppress(OSError):
+                    os.remove(tmp_file)
 
 
 def http_json(method: str, url: str, body: dict | None = None) -> dict:
@@ -586,7 +598,7 @@ def main():
     t.start()
 
     addr = ("0.0.0.0", LISTEN_PORT)
-    httpd = HTTPServer(addr, ImageRequestHandler)
+    httpd = ThreadingHTTPServer(addr, ImageRequestHandler)
     print(
         f"[start] Listening on {addr[0]}:{addr[1]} | resources={RESOURCE_IDS} | retention_minutes={RETENTION_MINUTES} | cleanup_interval_minutes={CLEANUP_INTERVAL_MINUTES}"
     )

--- a/codebase-analysis-docs/REMEDIATION_PLAN.md
+++ b/codebase-analysis-docs/REMEDIATION_PLAN.md
@@ -1,0 +1,425 @@
+# Codebase Analysis & Remediation Plan — `pangolin-ip-rule-manager`
+
+**Audit date:** 2026-07-01
+**Audited revision:** `claude/security-code-audit-yhi1vt` (HEAD `0356504`)
+**Scope:** Full repository — application code, connectors, templates, container build, CI/CD, and configuration.
+
+---
+
+## 1. Executive summary
+
+`pangolin-ip-rule-manager` is a small, focused Python 3.14 stdlib-only service that bootstraps
+network trust for non-SSO devices by writing temporary IP bypass rules into Pangolin (and
+optionally a CrowdSec allowlist). Overall the project is in **good health for its size**:
+
+- **Test coverage is strong** — 185 tests pass, covering the authorization chain, fail-closed
+  behaviour, retry/backoff, state round-trips, and the CrowdSec parsing helpers.
+- **Linting is clean** — `ruff check .` and `ruff format --check .` both pass.
+- **Security fundamentals are mostly right** — fail-closed authorization, HTTPS enforcement on
+  the Pangolin URL, `subprocess.run` with argument lists (no `shell=True`), IP and allowlist-name
+  validation, token redaction helper, atomic-ish state writes with `chmod 600`, non-root container
+  user, and SHA-pinned GitHub Actions.
+
+The issues found are concentrated in three areas: **(a) trust-boundary assumptions** around
+forwarded headers, **(b) a reflected-XSS gap** in the check-in page details, and **(c) infrastructure
+drift** — a `:latest` image tag that is referenced but never published, and missing `pip` Dependabot
+coverage. None of the findings indicate an actively exploited hole, but the XSS gap and the
+header-trust model are the two that warrant prompt attention because this service gates access to
+production resources.
+
+**Severity tally:** Critical 0 · High 3 · Medium 7 · Low 6
+
+> **Process note (per `CLAUDE.md`):** changes touching IP extraction, the authorization chain,
+> TTL/cleanup logic, or Pangolin/CrowdSec calls must be validated against the test instance before
+> production, and each concern should land as its own PR with a single release-notes label. This
+> plan groups fixes by concern to make that split straightforward.
+
+---
+
+## 2. Prioritized findings
+
+### Severity legend
+- **Critical** — remote compromise / auth bypass / data loss, exploitable as shipped.
+- **High** — security weakness or reliability defect with a realistic trigger in this deployment.
+- **Medium** — hardening gap, correctness bug with limited blast radius, or notable infra drift.
+- **Low** — quality, maintainability, and defense-in-depth improvements.
+
+---
+
+## HIGH
+
+### H-1 — Reflected XSS via unescaped detail strings in the check-in page
+- **Files / lines:** `request_handler.py:174-176` (`PANGOLIN_DETAIL`, `CROWDSEC_DETAIL`),
+  `request_handler.py:155` and `request_handler.py:184` (`site_name` in `SITE_NAME_SUB`),
+  `_build_checkin_html` / `_build_error_html`.
+- **Claim:** `_load_template` does a blind `str.replace` of `{{TOKEN}}` with the provided value
+  (`request_handler.py:22-27`). Most tokens are static, but `PANGOLIN_DETAIL` and `CROWDSEC_DETAIL`
+  carry `results[...]["detail"]`, which is exception text from the upstream API path — it can include
+  the raw HTTP error body returned by Pangolin (`http_json` at `app.py:162-167`) and the
+  `Remote-User` value (`pangolin_connector.py` messages embed `username!r}`). None of these are run
+  through `html.escape` before interpolation.
+- **Failure scenario:** A Pangolin/upstream error message (or a crafted `Remote-User`) containing
+  `<img src=x onerror=...>` is reflected verbatim into the details `<span>` and executes in the
+  visitor's browser. The `/update` error path already escapes `raw_ip` (`request_handler.py:321`),
+  and `CLAUDE.md` explicitly calls out that user-controlled strings must be `html.escape()`d — this
+  path was missed.
+- **Fix:** Escape every dynamic value at the interpolation boundary. Minimal, targeted change:
+
+```python
+# request_handler.py — inside _build_checkin_html, before building the tokens dict
+import html  # already imported at top
+
+safe_pangolin_detail = html.escape(str(pangolin_detail))
+safe_crowdsec_detail = html.escape(str(crowdsec_detail_display))
+# ...
+        {
+            # ...
+            "PANGOLIN_DETAIL": safe_pangolin_detail,
+            "CROWDSEC_DETAIL": safe_crowdsec_detail,
+            # ...
+        },
+```
+
+```python
+# request_handler.py — _build_checkin_html and _build_error_html
+site_name_sub = (
+    f'      <div class="sub">{html.escape(site_name)}</div>\n' if site_name else ""
+)
+# and in _build_error_html:
+site_name_footer = f"{html.escape(site_name)} &nbsp;&middot;&nbsp; " if site_name else ""
+```
+  A stronger structural fix is to make `_load_template` escape by default and require callers to
+  opt out for pre-built HTML fragments (`ACTIONS_SECTION`, `BOOKMARK_SECTION`), but the targeted
+  escapes above close the hole with minimal risk. Add a regression test that feeds
+  `detail = '<script>alert(1)</script>'` and asserts the rendered body contains the escaped form.
+- **Validation:** unit test + manual check against the test instance (touches HTML rendering only,
+  not the auth chain).
+
+### H-2 — `:latest` image tag is referenced but never published (registry/release drift)
+- **Files / lines:** `docker-compose.yml:3` (`image: ghcr.io/...:latest`) vs
+  `.github/workflows/docker-publish.yml:33-34` (`tags: type=semver,pattern={{version}}` only).
+- **Claim:** The publish workflow only emits a version tag (e.g. `2.3.0`). No step ever pushes or
+  moves a `latest` tag. The reference `docker-compose.yml` — the documented deployment artifact —
+  pulls `:latest`. There is therefore no guarantee the tag resolves to any build produced by this
+  pipeline; whatever `:latest` currently points to on GHCR is unverified against release assets.
+- **Failure scenario:** An operator does `docker compose pull` expecting the newest release and
+  either gets an image that predates the pipeline's tagging scheme, a stale manual push, or a pull
+  failure. Because there's no staging (`CLAUDE.md` / D7), this surfaces directly in production.
+- **Fix (choose one):**
+  1. **Publish `latest` in CI** (recommended) — add it to the metadata step so releases move the tag:
+```yaml
+# .github/workflows/docker-publish.yml
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 #v6.1.0
+        with:
+          images: ghcr.io/joe-cole1/pangolin-ip-rule-manager
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest,enable={{is_default_branch}}
+```
+  2. **Or pin compose to versions** — change `docker-compose.yml:3` to a specific tag
+     (`:2.3.0`) and document bumping it per release. This is the safer supply-chain posture
+     (immutable, auditable deploys) and fits the "every change is high-stakes" constraint.
+- **Validation:** cut a test release/tag and confirm both `:<version>` and (if option 1) `:latest`
+  resolve to the same digest; verify `docker compose pull` succeeds.
+
+### H-3 — Trust in forwarded identity headers has no cryptographic anchor
+- **Files / lines:** `request_handler.py:242-254` (`_get_real_ip` trusts `X-Real-IP`/`X-Forwarded-For`),
+  `request_handler.py:282` (`Remote-User` read directly), authorization chain `app.py:246-320`.
+- **Claim:** Authorization keys entirely off the `Remote-User` header and the client IP off
+  `X-Real-IP`/`X-Forwarded-For`. The service assumes these can only be set by the upstream
+  Pangolin/Traefik proxy. There is no shared-secret / signed-header check verifying the request
+  actually transited that proxy. The tests at `tests/test_app.py:976-1024` document that a former
+  `EXPECTED_PANGOLIN_CUSTOM_HEADER_*` gate was **removed**, so the only remaining barrier is network
+  topology.
+- **Failure scenario:** If the container port (`0.0.0.0:8080`, `app.py:576`) is ever reachable
+  without going through Pangolin — a misconfigured Docker network, an exposed port, an SSRF pivot
+  from a co-located container — an attacker sets `Remote-User: <any valid org user>` and
+  `X-Forwarded-For: <attacker IP>` and self-authorizes an IP bypass rule for protected resources.
+  The fail-closed logic does not help here because the attacker supplies a *valid* username.
+- **Fix:** Re-introduce a defense-in-depth shared secret that only the proxy knows, checked before
+  any state write or API fan-out. Keep it optional-but-warned to avoid breaking existing deploys,
+  mirroring the existing token-missing warning pattern:
+```python
+# app.py (config)
+PROXY_SHARED_SECRET = os.getenv("PROXY_SHARED_SECRET", "")
+
+# request_handler.py, at the very top of do_GET, before any state mutation:
+expected = ctx.get("proxy_shared_secret", "")
+if expected:
+    import hmac
+    provided = self.headers.get("X-Proxy-Secret", "")
+    if not hmac.compare_digest(provided, expected):
+        self.send_response(403); self.end_headers()
+        self.wfile.write(b"Forbidden")
+        return
+```
+  Configure Traefik/Pangolin to inject `X-Proxy-Secret` (and strip any client-supplied copy).
+  Document that the container must never be published directly. Also confirm the proxy strips
+  inbound `Remote-User`/`X-Real-IP` from clients so they cannot be spoofed end-to-end.
+- **Validation:** touches the authorization chain and IP extraction — **must** be validated against
+  the test instance before production, per `CLAUDE.md`. Add tests for present/absent/wrong secret.
+
+---
+
+## MEDIUM
+
+### M-1 — Single-threaded server blocks all traffic on slow upstream calls
+- **Files / lines:** `app.py:577` (`HTTPServer`), upstream calls with 20s timeout ×3 retries
+  (`app.py:155`, `pangolin_connector.py:11-33`).
+- **Claim:** `http.server.HTTPServer` is single-threaded. Each check-in can trigger multiple
+  Pangolin GET/PUT calls, each up to 20s with up to 3 retries and exponential backoff. One slow or
+  hanging upstream stalls every other request, including health checks.
+- **Fix:** Use a threaded server:
+```python
+from http.server import ThreadingHTTPServer
+httpd = ThreadingHTTPServer(addr, ImageRequestHandler)
+```
+  Note the shared caches (`rules_cache`, `_api_rate_limit`, CrowdSec cache) are already guarded by
+  locks, so threading is safe. Verify the state file write path (see M-2) under concurrency.
+- **Validation:** reliability change; run the suite and a concurrent-request smoke test.
+
+### M-2 — `save_state` uses a single shared temp path — concurrent writers race
+- **Files / lines:** `app.py:131-141` (`tmp_file = STATE_FILE + ".tmp"`).
+- **Claim:** The cleanup thread and request handlers both call `save_state`. All writers use the
+  same `state.json.tmp` path, so two concurrent writes can interleave and `os.replace` a partial or
+  wrong-writer file. Becomes materially more likely if M-1 (threading) is adopted.
+- **Fix:** Serialize saves with a dedicated lock and/or a unique temp name:
+```python
+_save_lock = threading.Lock()
+
+def save_state():
+    with _save_lock:
+        with state_lock:
+            snapshot = json.dumps(state, indent=2, sort_keys=True)
+        fd, tmp_file = tempfile.mkstemp(dir=os.path.dirname(os.path.abspath(STATE_FILE)))
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(snapshot)
+            os.replace(tmp_file, STATE_FILE)
+            os.chmod(STATE_FILE, 0o600)
+        except Exception as e:
+            print(f"[state] failed to save state: {e}")
+            with contextlib.suppress(OSError):
+                os.remove(tmp_file)
+```
+- **Validation:** touches state persistence; run state round-trip tests + concurrency smoke test.
+
+### M-3 — Rule cache not invalidated after deletion → stale "rule exists" reads
+- **Files / lines:** `pangolin_connector.py:147-190` (`delete_ip_rule_if_created_by_us` never touches
+  `ctx.rules_cache`), consumed by `get_ip_set_for_resource_cached` (`pangolin_connector.py:53-84`).
+- **Claim:** On creation the code updates `rules_cache` (`pangolin_connector.py:124-129`), but on
+  deletion it does not remove the IP. For up to `RULES_CACHE_TTL_SECONDS` (1h default) after cleanup
+  deletes a rule, a re-check-in from the same IP sees the cached entry, logs "rule already exists",
+  and skips re-creation — leaving the user without access until the cache expires.
+- **Fix:** Invalidate the cached IP on successful delete:
+```python
+# after a successful DELETE in delete_ip_rule_if_created_by_us:
+with ctx.state_lock:
+    entry = ctx.rules_cache.get(rid)
+    if entry and ip in entry.get("ip_set", set()):
+        entry["ip_set"].discard(ip)
+```
+- **Validation:** touches TTL/cache + Pangolin API logic; add a test asserting cache eviction on
+  delete; validate against test instance.
+
+### M-4 — `pip` ecosystem missing from Dependabot (coverage regression)
+- **Files / lines:** `.github/dependabot.yml:1-11` (only `github-actions` + `docker`).
+- **Claim:** `requirements.txt` pins `pytest` and `ruff`, and the git history shows past pip
+  Dependabot PRs (e.g. `pip/pip-590e9db7b9` in `git log`). The current config has no `pip` entry, so
+  those dev dependencies no longer receive security/version updates automatically.
+- **Fix:**
+```yaml
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+```
+- **Validation:** config only; confirm Dependabot picks up `requirements.txt` after merge.
+
+### M-5 — `redact_headers_for_log` is dead code; request logging is not actually redacted
+- **Files / lines:** `app.py:103-115` (defined), `app.py:441` (injected into ctx), never invoked in
+  `request_handler.py`. Request logging is `print(f"New request from {ip}  user: {remote_user} ...")`
+  (`request_handler.py:284`) and `log_message` (`request_handler.py:218-219`).
+- **Claim:** The redaction helper is fully tested but never called on a real request path. It gives
+  a false sense that sensitive headers are scrubbed from logs; in practice no header dump is logged
+  at all, and the helper is drift-prone dead code.
+- **Fix:** Either wire it into an actual (debug-gated) header dump, or remove it and its tests if
+  header logging is intentionally absent. If kept, call it where headers would be logged:
+```python
+if DEBUG_HEADERS:
+    print("[http] headers:", ctx["redact_headers_for_log"](dict(self.headers)))
+```
+- **Validation:** low-risk; keep the existing unit tests if the function is retained.
+
+### M-6 — Container and compose lack runtime hardening flags
+- **Files / lines:** `Dockerfile:1` (`FROM python:3.14-alpine`, tag not digest-pinned),
+  `docker-compose.yml:1-90` (no `security_opt`, `cap_drop`, `read_only`, `tmpfs`).
+- **Claim:** The image runs as non-root (good) but the base is not digest-pinned (supply-chain
+  drift), and the compose service does not drop capabilities, set `no-new-privileges`, or mount the
+  root FS read-only. `docker-cli` is installed unconditionally even when CrowdSec is disabled,
+  widening the attack surface.
+- **Fix:**
+  - Pin the base image by digest: `FROM python:3.14-alpine@sha256:...`.
+  - Add to the compose service:
+```yaml
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /tmp
+```
+    (Keep the `/data` volume writable for state.)
+  - Consider a build arg to skip `docker-cli` when CrowdSec integration is not used.
+- **Validation:** rebuild image, run container, confirm state writes and (if enabled) CrowdSec exec
+  still work under the hardened flags.
+
+### M-7 — No Content-Security-Policy; templates fetch external Google Fonts
+- **Files / lines:** `request_handler.py:260-262` (`_send_security_headers` sets only
+  `X-Content-Type-Options` and `X-Frame-Options`), `templates/checkin.html:8` and
+  `templates/error.html:8` (`@import url('https://fonts.googleapis.com/...')`).
+- **Claim:** There is no CSP header, so the XSS in H-1 has no second line of defense. The templates
+  also pull fonts from Google, leaking each visitor's IP/User-Agent to a third party and adding an
+  external dependency for pages served to authenticate access.
+- **Fix:** Add a restrictive CSP and self-host or drop the web fonts:
+```python
+def _send_security_headers(self) -> None:
+    self.send_header("X-Content-Type-Options", "nosniff")
+    self.send_header("X-Frame-Options", "DENY")
+    self.send_header("Referrer-Policy", "no-referrer")
+    self.send_header(
+        "Content-Security-Policy",
+        "default-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; "
+        "script-src 'unsafe-inline'; base-uri 'none'; form-action 'none'",
+    )
+```
+  Note the inline `<script>`/`<style>` in the templates require `'unsafe-inline'` unless refactored
+  to hashed/nonce'd blocks; removing the Google Fonts `@import` lets you drop `fonts.googleapis.com`
+  from the policy entirely. Pair this with H-1 for meaningful protection.
+- **Validation:** render both pages, confirm styling/scripts still work with the CSP applied.
+
+---
+
+## LOW
+
+### L-1 — Duplicated CrowdSec config/state between `app.py` and `crowdsec_connector.py`
+- **Files / lines:** `app.py:44-59` and `app.py:89-92` re-parse `CROWDSEC_*` env vars and declare
+  `_crowdsec_allowlist_ready` / `crowdsec_cache`, which duplicate/shadow the authoritative copies in
+  `crowdsec_connector.py:12-28`. The app-level `crowdsec_cache` and `_crowdsec_allowlist_ready` are
+  never read by the connector.
+- **Fix:** Delete the unused app-level CrowdSec globals; keep only what `app.py` genuinely needs
+  (`CROWDSEC_ENABLED` for `TARGETS` registration and self-check display). Import the rest from the
+  connector if needed.
+
+### L-2 — `Target` polymorphism undercut by `isinstance` branching
+- **Files / lines:** `app.py:296-302` (`isinstance(t, PangolinTarget/CrowdSecTarget)`),
+  `app.py:188` (`PangolinTarget.add_ip` has an extra `resource_ids` param the base class lacks).
+- **Fix:** Give `Target.add_ip(ip, context)` a uniform signature (pass effective resource IDs to all
+  targets; CrowdSec ignores them), so `add_ip_to_targets` can loop without type checks. Reduces the
+  chance of a future target being mis-handled.
+
+### L-3 — CrowdSec allowlist existence check uses substring match
+- **Files / lines:** `crowdsec_connector.py:194-198` (`if name in out3`).
+- **Fix:** The JSON paths are exact; the plain-text fallback should match a whole token/line rather
+  than a substring, so an allowlist named `pang` doesn't false-match `pangolin-ip-rule-manager`.
+  Prefer failing to the JSON path or line-splitting and comparing trimmed tokens.
+
+### L-4 — CrowdSec CIDR entries collapse to the network address only
+- **Files / lines:** `crowdsec_connector.py:261-285` (`_parse_crowdsec_entries_from_json` stores
+  `str(net.network_address)`).
+- **Fix:** Membership checks (`_crowdsec_ip_known_or_refresh`, `crowdsec_remove_ip`) compare exact
+  IP strings, so an IP inside an existing CIDR allowlist entry is treated as "not present" and
+  re-added. If CIDR entries are expected, store the network objects and test containment; otherwise
+  document that only exact-IP entries are managed.
+
+### L-5 — HEALTHCHECK only proves the process is alive, not that it serves
+- **Files / lines:** `Dockerfile:34-35` and `docker-compose.yml:85-90` (`pgrep -f app.py`).
+- **Fix:** A hung single-threaded server (see M-1) still passes `pgrep`. Add a lightweight HTTP
+  liveness route (e.g. `/healthz` returning 200 without touching Pangolin) and healthcheck against
+  it, or curl a known `.png` path. Keep it cheap so it doesn't trigger auth/API work.
+
+### L-6 — Missing repo hygiene files: LICENSE, SECURITY.md, pyproject.toml
+- **Files / lines:** repository root (none present).
+- **Fix:** Add a LICENSE (clarifies reuse terms for a public GHCR image), a SECURITY.md with a
+  disclosure contact, and a `pyproject.toml` to pin the ruff config/target-version explicitly rather
+  than relying on ruff defaults across contributor environments.
+
+---
+
+## 3. Suggested PR sequencing (one concern per PR, per `CLAUDE.md`)
+
+| Order | Concern | Findings | Suggested label |
+|---|---|---|---|
+| 1 | Escape XSS in check-in/error pages | H-1 | `security` |
+| 2 | Fix `:latest` publish/pin drift | H-2 | `bug` / `security` |
+| 3 | Shared-secret proxy header check | H-3 | `security` |
+| 4 | Threaded server + safe state writes | M-1, M-2 | `bug` |
+| 5 | Rule-cache invalidation on delete | M-3 | `bug` |
+| 6 | Add pip Dependabot ecosystem | M-4 | `dependencies` |
+| 7 | Container/compose hardening + CSP | M-6, M-7 | `security` |
+| 8 | Cleanup: dead code, polymorphism, hygiene | L-1..L-6, M-5 | `chore` |
+
+Items 3, 4, and 5 touch the auth chain / TTL / API interactions and **must be validated against the
+test instance** before production, per the project's behavioral rules.
+
+---
+
+## 4. Architecture diagram (current state + improvement points)
+
+```mermaid
+flowchart TD
+    subgraph client["Client devices"]
+        phone["Family phone<br/>(SSO-authenticated)"]
+        tv["TV / non-SSO device"]
+    end
+
+    subgraph edge["Edge (Oracle VPS)"]
+        traefik["Traefik + Pangolin SSO<br/>injects Remote-User / X-Real-IP"]
+    end
+
+    subgraph app["pangolin-ip-rule-manager container (non-root)"]
+        server["HTTPServer :8080<br/>⚠️ M-1 single-threaded"]
+        handler["request_handler.py<br/>_get_real_ip / do_GET<br/>⚠️ H-1 unescaped detail HTML<br/>⚠️ H-3 header trust only"]
+        authz["app.add_ip_to_targets<br/>fail-closed authz"]
+        pgconn["pangolin_connector.py<br/>⚠️ M-3 cache not evicted on delete"]
+        csconn["crowdsec_connector.py<br/>subprocess cscli<br/>⚠️ L-3/L-4 match gaps"]
+        cleanup["cleanup_loop thread"]
+        state[("state.json<br/>chmod 600<br/>⚠️ M-2 shared .tmp race")]
+    end
+
+    subgraph ext["External systems"]
+        pangolinapi["Pangolin Integration API<br/>(HTTPS, Bearer token)"]
+        crowdsec["CrowdSec container<br/>via docker exec"]
+        fonts["Google Fonts<br/>⚠️ M-7 external fetch / no CSP"]
+    end
+
+    phone -->|"trigger URL<br/>*.png / /update"| traefik
+    traefik -->|"proxied + headers"| server
+    tv -.->|"same public IP,<br/>reaches Jellyfin after rule"| traefik
+    server --> handler --> authz
+    authz --> pgconn --> pangolinapi
+    authz --> csconn --> crowdsec
+    handler --> state
+    cleanup --> state
+    cleanup --> pgconn
+    cleanup --> csconn
+    handler -.->|"HTML page @import"| fonts
+
+    classDef weak stroke:#e5484d,stroke-width:2px;
+    class server,handler,pgconn,csconn,state weak;
+```
+
+**Where structural improvement pays off most:**
+1. **Trust boundary (`traefik → server`, H-3):** add a shared-secret header verified before any
+   state write or API call, so the container is safe even if its port is exposed.
+2. **Presentation layer (H-1, M-7):** escape-by-default templating + a CSP turns the check-in page
+   from a reflected-XSS surface into a hardened, self-contained page.
+3. **Concurrency & persistence (M-1, M-2):** a threaded server with serialized, uniquely-named state
+   writes removes the head-of-line blocking and the temp-file race in one coherent change.
+4. **Cache coherence (M-3):** invalidating `rules_cache` on delete keeps in-memory state, on-disk
+   state, and Pangolin's actual rules aligned across the create/cleanup cycle.
+5. **Supply chain (H-2, M-4, M-6):** publish/pin image tags deterministically, restore pip
+   Dependabot, and digest-pin + harden the container to make production deploys auditable.

--- a/config.env.sample
+++ b/config.env.sample
@@ -56,3 +56,7 @@ RATE_LIMIT_SECONDS=300  # seconds between Pangolin API fan-out calls per IP (0 t
 # with 403 before any state write or API call. Configure the proxy to add this header
 # and to strip any client-supplied copy. Leave empty to disable.
 PROXY_SHARED_SECRET=
+
+# Log every request's headers (Authorization/Proxy-Authorization redacted) for
+# debugging. Leave false in production.
+DEBUG_LOG_HEADERS=false

--- a/config.env.sample
+++ b/config.env.sample
@@ -50,3 +50,9 @@ CROWDSEC_CSCLI_BIN=cscli
 SITE_NAME=   # shown in HTML page header/footer; leave empty to omit
 UPDATE_ENDPOINT_ENABLED=false
 RATE_LIMIT_SECONDS=300  # seconds between Pangolin API fan-out calls per IP (0 to disable)
+
+# Defense-in-depth: shared secret the upstream proxy (Pangolin/Traefik) must inject as
+# the X-Proxy-Secret header. When set, requests without a matching header are rejected
+# with 403 before any state write or API call. Configure the proxy to add this header
+# and to strip any client-supplied copy. Leave empty to disable.
+PROXY_SHARED_SECRET=

--- a/crowdsec_connector.py
+++ b/crowdsec_connector.py
@@ -190,11 +190,12 @@ def crowdsec_allowlist_exists(name: str) -> bool:
                     )
             except Exception:
                 pass
-    # Fallback: plain text search
+    # Fallback: plain text search. Match a whole whitespace-delimited token rather
+    # than a substring so a shorter name cannot false-match a longer allowlist name.
     for args in (["allowlist", "list"], ["allowlists", "list"]):
         rc3, out3, _ = run_cscli(args)
         if rc3 == 0 and out3:
-            if name in out3:
+            if name in out3.split():
                 return True
     return False
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,14 @@ services:
       # ---------------------------------------------------------------------------
       UPDATE_ENDPOINT_ENABLED: "false"
 
+      # ---------------------------------------------------------------------------
+      # Defense-in-depth shared secret (optional, STRONGLY RECOMMENDED)
+      # ---------------------------------------------------------------------------
+      # When set, the upstream proxy must inject a matching X-Proxy-Secret header or
+      # the request is rejected with 403 before any state write or API call. Configure
+      # Pangolin/Traefik to add this header and strip any client-supplied copy.
+      # PROXY_SHARED_SECRET: ${PROXY_SHARED_SECRET}
+
     volumes:
       - pangolin-ip-rule-manager-data:/data
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,7 +107,8 @@ services:
           memory: "256M"
 
     healthcheck:
-      test: ["CMD-SHELL", "pgrep -f app.py || exit 1"]
+      test:
+        ["CMD-SHELL", "wget -q -O - http://127.0.0.1:${LISTEN_PORT:-8080}/healthz || exit 1"]
       interval: 60s
       timeout: 5s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,6 +84,22 @@ services:
 
     restart: unless-stopped
 
+    # ---------------------------------------------------------------------------
+    # Runtime hardening
+    # ---------------------------------------------------------------------------
+    # The root filesystem is read-only; only the /data volume (state) and an
+    # in-memory /tmp are writable. All Linux capabilities are dropped and
+    # privilege escalation is disabled. If you enable CrowdSec via a local
+    # `docker exec` prefix, the docker CLI may need a writable HOME — prefer the
+    # socket-proxy + DOCKER_HOST path, which keeps these flags intact.
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /tmp
+
     deploy:
       resources:
         limits:

--- a/pangolin_connector.py
+++ b/pangolin_connector.py
@@ -184,6 +184,13 @@ def delete_ip_rule_if_created_by_us(ctx: PangolinContext, ip: str, rid: int) -> 
                 deleted_any = True
             except Exception as e:
                 print(f"[pangolin] delete failed for rule {rule_id} on {rid}: {e}")
+        if deleted_any:
+            # Evict the IP from the existence cache so a re-check-in re-creates the
+            # rule instead of trusting a stale "already exists" entry until TTL expiry.
+            with ctx.state_lock:
+                entry = ctx.rules_cache.get(rid)
+                if entry:
+                    entry.get("ip_set", set()).discard(ip)
         return deleted_any
     except Exception as e:
         print(f"[pangolin] fetch rules (delete phase) failed for {rid}, ip {ip}: {e}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+# Tooling configuration. The application itself is Python 3.14 stdlib-only and has
+# no runtime dependencies; this file only pins linter/formatter settings so results
+# are consistent across contributor environments and CI.
+#
+# Note: target-version is intentionally left at ruff's default. Pinning it to py314
+# makes `ruff format` rewrite `except (A, B):` into the PEP 758 unparenthesized form,
+# which is a SyntaxError on the older interpreters commonly used for local dev/CI.
+# Keep the parenthesized form for compatibility.
+
+[tool.ruff]
+line-length = 88
+
+[tool.ruff.format]
+quote-style = "double"

--- a/request_handler.py
+++ b/request_handler.py
@@ -1,3 +1,4 @@
+import hmac
 import html
 import ipaddress
 import json
@@ -216,6 +217,7 @@ def create_image_request_handler(ctx: dict):
       - banner_gif: bytes
       - redact_headers_for_log: callable (headers: dict[str, str]) -> dict[str, str]
       - site_name: str
+      - proxy_shared_secret: str (optional; when set, X-Proxy-Secret must match)
     """
 
     class ImageRequestHandler(BaseHTTPRequestHandler):
@@ -263,6 +265,17 @@ def create_image_request_handler(ctx: dict):
             accept = self.headers.get("Accept", "")
             return "text/html" in accept
 
+        def _proxy_secret_ok(self) -> bool:
+            """Defense-in-depth gate. When PROXY_SHARED_SECRET is configured, the
+            upstream proxy must inject a matching X-Proxy-Secret header. Compared with
+            hmac.compare_digest to avoid timing leaks. Returns True when no secret is
+            configured (feature disabled) or the provided secret matches."""
+            expected = ctx.get("proxy_shared_secret", "")
+            if not expected:
+                return True
+            provided = self.headers.get("X-Proxy-Secret", "")
+            return hmac.compare_digest(provided, expected)
+
         def _send_security_headers(self) -> None:
             self.send_header("X-Content-Type-Options", "nosniff")
             self.send_header("X-Frame-Options", "DENY")
@@ -282,6 +295,17 @@ def create_image_request_handler(ctx: dict):
             self.wfile.write(encoded)
 
         def do_GET(self):
+            # Defense-in-depth: reject anything that did not transit the proxy before
+            # touching state or the Pangolin/CrowdSec APIs. Bare 403, no body detail.
+            if not self._proxy_secret_ok():
+                self.send_response(403)
+                self.end_headers()
+                self.wfile.write(b"Forbidden")
+                print(
+                    f"[error] Rejected request with missing/invalid X-Proxy-Secret: {self.path}"
+                )
+                return
+
             ip = self._get_real_ip()
             parsed_path = urlparse(self.path)
             path = parsed_path.path or "/"

--- a/request_handler.py
+++ b/request_handler.py
@@ -309,6 +309,20 @@ def create_image_request_handler(ctx: dict):
             self.wfile.write(encoded)
 
         def do_GET(self):
+            parsed_path = urlparse(self.path)
+            path = parsed_path.path or "/"
+
+            # Liveness probe — intentionally before the proxy-secret gate so container
+            # health checks work regardless of PROXY_SHARED_SECRET. Touches no state and
+            # makes no upstream calls.
+            if path == "/healthz":
+                self.send_response(200)
+                self.send_header("Content-Type", "text/plain; charset=utf-8")
+                self.send_header("Content-Length", "2")
+                self.end_headers()
+                self.wfile.write(b"ok")
+                return
+
             # Defense-in-depth: reject anything that did not transit the proxy before
             # touching state or the Pangolin/CrowdSec APIs. Bare 403, no body detail.
             if not self._proxy_secret_ok():
@@ -321,8 +335,6 @@ def create_image_request_handler(ctx: dict):
                 return
 
             ip = self._get_real_ip()
-            parsed_path = urlparse(self.path)
-            path = parsed_path.path or "/"
             remote_user = self.headers.get("Remote-User", "")
 
             print(f"New request from {ip}  user: {remote_user}  path: {path}")

--- a/request_handler.py
+++ b/request_handler.py
@@ -279,6 +279,20 @@ def create_image_request_handler(ctx: dict):
         def _send_security_headers(self) -> None:
             self.send_header("X-Content-Type-Options", "nosniff")
             self.send_header("X-Frame-Options", "DENY")
+            self.send_header("Referrer-Policy", "no-referrer")
+            # All CSS/JS is inline and self-contained (no external fetches), so a
+            # restrictive policy is possible. 'unsafe-inline' is still required for
+            # the inline <style>/<script> blocks; everything else is locked down.
+            self.send_header(
+                "Content-Security-Policy",
+                "default-src 'none'; "
+                "img-src 'self' data:; "
+                "style-src 'unsafe-inline'; "
+                "script-src 'unsafe-inline'; "
+                "base-uri 'none'; "
+                "form-action 'none'; "
+                "frame-ancestors 'none'",
+            )
 
         def _send_html(self, status: int, body: str) -> None:
             encoded = body.encode("utf-8")

--- a/request_handler.py
+++ b/request_handler.py
@@ -152,7 +152,9 @@ def _build_checkin_html(
     else:
         actions_section = ""
 
-    site_name_sub = f'      <div class="sub">{site_name}</div>\n' if site_name else ""
+    site_name_sub = (
+        f'      <div class="sub">{html.escape(site_name)}</div>\n' if site_name else ""
+    )
 
     return _load_template(
         "checkin.html",
@@ -171,9 +173,9 @@ def _build_checkin_html(
             "DETAILS_LABEL": details_label,
             "DETAILS_IP": ip,
             "PANGOLIN_DETAIL_CLASS": pangolin_detail_class,
-            "PANGOLIN_DETAIL": pangolin_detail,
+            "PANGOLIN_DETAIL": html.escape(str(pangolin_detail)),
             "CROWDSEC_DETAIL_CLASS": crowdsec_detail_class,
-            "CROWDSEC_DETAIL": crowdsec_detail_display,
+            "CROWDSEC_DETAIL": html.escape(str(crowdsec_detail_display)),
             "EXPIRES_ISO": expires_iso,
             "LAST_SEEN": last_seen,
         },
@@ -181,8 +183,12 @@ def _build_checkin_html(
 
 
 def _build_error_html(title: str, message: str, site_name: str = "") -> str:
-    site_name_sub = f'      <div class="sub">{site_name}</div>\n' if site_name else ""
-    site_name_footer = f"{site_name} &nbsp;&middot;&nbsp; " if site_name else ""
+    site_name_sub = (
+        f'      <div class="sub">{html.escape(site_name)}</div>\n' if site_name else ""
+    )
+    site_name_footer = (
+        f"{html.escape(site_name)} &nbsp;&middot;&nbsp; " if site_name else ""
+    )
     return _load_template(
         "error.html",
         {

--- a/request_handler.py
+++ b/request_handler.py
@@ -339,6 +339,11 @@ def create_image_request_handler(ctx: dict):
 
             print(f"New request from {ip}  user: {remote_user}  path: {path}")
 
+            if ctx.get("debug_log_headers"):
+                redact = ctx.get("redact_headers_for_log")
+                if redact:
+                    print("[http] headers:", redact(dict(self.headers)))
+
             lower_path = path.lower()
 
             # /update?ip=1.2.3.4 endpoint (guarded by UPDATE_ENDPOINT_ENABLED)

--- a/templates/checkin.html
+++ b/templates/checkin.html
@@ -5,7 +5,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Network Check-in</title>
 <style>
-  @import url('https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Space+Grotesk:wght@300..700&display=swap');
   :root {
     --bg:              #0C0C0D;
     --surface:         #141415;

--- a/templates/error.html
+++ b/templates/error.html
@@ -5,7 +5,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>{{ERROR_TITLE}}</title>
 <style>
-  @import url('https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Space+Grotesk:wght@300..700&display=swap');
   :root {
     --bg:              #0C0C0D;
     --surface:         #141415;

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1700,6 +1700,25 @@ def test_proxy_secret_unset_disables_gate(monkeypatch, temp_state_file):
         assert resp.status == 200
 
 
+def test_healthz_ok_and_bypasses_secret_gate(monkeypatch, temp_state_file):
+    """/healthz returns 200 with no auth, even when the proxy-secret gate is armed,
+    and does not write any state."""
+    app = _reload_app_with_secret(monkeypatch, temp_state_file, "s3cret")
+    with app.state_lock:
+        app.state.clear()
+
+    with start_server(app.ImageRequestHandler) as (_httpd, port):
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("GET", "/healthz")
+        resp = conn.getresponse()
+        data = resp.read()
+        assert resp.status == 200
+        assert data == b"ok"
+
+    with app.state_lock:
+        assert app.state == {}, "healthz must not mutate state"
+
+
 # ---------------------------------------------------------------------------
 # HTML rendering — reflected XSS escaping (Finding H-1)
 # ---------------------------------------------------------------------------

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1619,6 +1619,62 @@ def test_get_real_ip_ipv6_accepted():
 
 
 # ---------------------------------------------------------------------------
+# HTML rendering — reflected XSS escaping (Finding H-1)
+# ---------------------------------------------------------------------------
+
+
+def test_checkin_html_escapes_pangolin_detail():
+    """Attacker-controlled detail text must be HTML-escaped, not reflected raw."""
+    import request_handler
+
+    payload = "<script>alert(1)</script>"
+    results = {
+        "pangolin": {"ok": False, "detail": payload},
+        "crowdsec": {"ok": False, "detail": "disabled"},
+    }
+    body = request_handler._build_checkin_html(
+        ip="1.2.3.4",
+        results=results,
+        retention_minutes=1440,
+        last_seen="2025-01-01T00:00:00+00:00",
+        crowdsec_enabled=False,
+    )
+    assert payload not in body, "Raw <script> payload must not appear in rendered HTML"
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in body
+
+
+def test_checkin_html_escapes_site_name():
+    """site_name must be HTML-escaped in the check-in header."""
+    import request_handler
+
+    results = {
+        "pangolin": {"ok": True, "detail": "ok"},
+        "crowdsec": {"ok": False, "detail": "disabled"},
+    }
+    body = request_handler._build_checkin_html(
+        ip="1.2.3.4",
+        results=results,
+        retention_minutes=1440,
+        last_seen="2025-01-01T00:00:00+00:00",
+        crowdsec_enabled=False,
+        site_name="<img src=x onerror=alert(1)>",
+    )
+    assert "<img src=x onerror=alert(1)>" not in body
+    assert "&lt;img src=x onerror=alert(1)&gt;" in body
+
+
+def test_error_html_escapes_site_name():
+    """site_name must be HTML-escaped in the error page header and footer."""
+    import request_handler
+
+    body = request_handler._build_error_html(
+        "Bad request", "Something went wrong.", site_name="<b>x</b>"
+    )
+    assert "<b>x</b>" not in body
+    assert "&lt;b&gt;x&lt;/b&gt;" in body
+
+
+# ---------------------------------------------------------------------------
 # pangolin_connector unit tests
 # ---------------------------------------------------------------------------
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1619,6 +1619,88 @@ def test_get_real_ip_ipv6_accepted():
 
 
 # ---------------------------------------------------------------------------
+# Proxy shared-secret gate (Finding H-3)
+# ---------------------------------------------------------------------------
+
+
+def _reload_app_with_secret(monkeypatch, temp_state_file, secret: str):
+    monkeypatch.setenv("PANGOLIN_TOKEN", "")
+    monkeypatch.setenv("RESOURCE_IDS", "5")
+    monkeypatch.setenv("LISTEN_PORT", "0")
+    monkeypatch.setenv("STATE_FILE", temp_state_file)
+    monkeypatch.setenv("PROXY_SHARED_SECRET", secret)
+    import app as _app
+
+    return importlib.reload(_app)
+
+
+def test_proxy_secret_missing_header_rejected(monkeypatch, temp_state_file):
+    """When PROXY_SHARED_SECRET is set, a request without X-Proxy-Secret gets 403
+    and no IP is written to state."""
+    app = _reload_app_with_secret(monkeypatch, temp_state_file, "s3cret")
+    with app.state_lock:
+        app.state.clear()
+
+    with start_server(app.ImageRequestHandler) as (_httpd, port):
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("GET", "/checkin.png", headers={"X-Real-IP": "1.2.3.4"})
+        resp = conn.getresponse()
+        _ = resp.read()
+        assert resp.status == 403
+
+    with app.state_lock:
+        assert "1.2.3.4" not in app.state, "no state write when secret gate fails"
+
+
+def test_proxy_secret_wrong_header_rejected(monkeypatch, temp_state_file):
+    """A mismatched X-Proxy-Secret is rejected with 403."""
+    app = _reload_app_with_secret(monkeypatch, temp_state_file, "s3cret")
+
+    with start_server(app.ImageRequestHandler) as (_httpd, port):
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request(
+            "GET",
+            "/checkin.png",
+            headers={"X-Real-IP": "1.2.3.4", "X-Proxy-Secret": "wrong"},
+        )
+        resp = conn.getresponse()
+        _ = resp.read()
+        assert resp.status == 403
+
+
+def test_proxy_secret_correct_header_allowed(monkeypatch, temp_state_file):
+    """A matching X-Proxy-Secret passes the gate and reaches the handler (200)."""
+    app = _reload_app_with_secret(monkeypatch, temp_state_file, "s3cret")
+    with app.state_lock:
+        app.state.clear()
+
+    with start_server(app.ImageRequestHandler) as (_httpd, port):
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request(
+            "GET",
+            "/checkin.png",
+            headers={"X-Real-IP": "1.2.3.4", "X-Proxy-Secret": "s3cret"},
+        )
+        resp = conn.getresponse()
+        _ = resp.read()
+        assert resp.status == 200
+
+
+def test_proxy_secret_unset_disables_gate(monkeypatch, temp_state_file):
+    """With no PROXY_SHARED_SECRET configured, requests are not gated (200)."""
+    app = _reload_app_with_secret(monkeypatch, temp_state_file, "")
+    with app.state_lock:
+        app.state.clear()
+
+    with start_server(app.ImageRequestHandler) as (_httpd, port):
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("GET", "/checkin.png", headers={"X-Real-IP": "1.2.3.4"})
+        resp = conn.getresponse()
+        _ = resp.read()
+        assert resp.status == 200
+
+
+# ---------------------------------------------------------------------------
 # HTML rendering — reflected XSS escaping (Finding H-1)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1823,6 +1823,26 @@ def test_delete_rule_success_returns_true():
     )
 
 
+def test_delete_rule_evicts_ip_from_rules_cache():
+    """A successful delete must remove the IP from rules_cache so a later check-in
+    re-creates the rule instead of trusting a stale 'already exists' entry."""
+    import pangolin_connector
+
+    def fake_http(method, url, body=None):
+        if method == "GET":
+            return {
+                "data": {"rules": [{"match": "IP", "value": "1.2.3.4", "ruleId": 42}]}
+            }
+        return {}
+
+    cache = {5: {"ts": 9e18, "ip_set": {"1.2.3.4", "9.9.9.9"}}}
+    ctx = _make_pg_ctx(http_json=fake_http, rules_cache=cache)
+
+    assert pangolin_connector.delete_ip_rule_if_created_by_us(ctx, "1.2.3.4", 5) is True
+    assert "1.2.3.4" not in cache[5]["ip_set"], "deleted IP must be evicted from cache"
+    assert "9.9.9.9" in cache[5]["ip_set"], "other cached IPs must be preserved"
+
+
 def test_delete_rule_no_rule_id_returns_false():
     """Matching rule has no ruleId field — skipped, deleted_any stays False, returns False."""
     import pangolin_connector


### PR DESCRIPTION
Implements the fixes from a full security/quality audit of the repository. Grouped one concern per commit so the set can be reviewed (or split) commit-by-commit.

The audit write-up lives in `codebase-analysis-docs/REMEDIATION_PLAN.md` and `STATE_BLOCK.md`.

## High

- **H-1 — Reflected XSS:** escape `pangolin_detail`, `crowdsec_detail`, and `site_name` before interpolating them into the check-in and error pages. Upstream API error text and `Remote-User` could previously reach the browser unescaped.
- **H-2 — `:latest` publish drift:** the publish workflow only emitted a version tag, but `docker-compose.yml` pulls `:latest`. Now publishes `latest` on release (`enable=${{ github.event_name == 'release' }}` — the workflow triggers on `release: published`, where the ref is the tag, so `is_default_branch` would never fire).
- **H-3 — Header trust:** add an optional `PROXY_SHARED_SECRET`. When set, the upstream proxy must inject a matching `X-Proxy-Secret` header or the request is rejected with 403 before any state write or API call. Disabled by default (empty), with a startup warning.

## Medium

- **M-1 / M-2 — Concurrency:** switch to `ThreadingHTTPServer` and make `save_state` race-free (dedicated save lock + unique `tempfile.mkstemp` temp file instead of a shared `.tmp`).
- **M-3 — Cache coherence:** evict the IP from `rules_cache` after a successful Pangolin rule delete, so a re-check-in re-creates the rule instead of trusting a stale "already exists" entry for up to the cache TTL.
- **M-4 — Dependabot:** add the `pip` ecosystem (regressed coverage for `requirements.txt`).
- **M-5 — Logging:** wire the tested `redact_headers_for_log` helper into an optional `DEBUG_LOG_HEADERS` request-header dump so it is live rather than dead code.
- **M-6 / M-7 — Container & headers:** digest-pin the base image (Dependabot keeps it fresh), add compose hardening (`no-new-privileges`, `cap_drop: ALL`, `read_only`, `tmpfs /tmp`), add a Content-Security-Policy and `Referrer-Policy: no-referrer`, and drop the external Google Fonts `@import` so pages are self-contained.

## Low / cleanup

- **L-1** — remove dead CrowdSec globals in `app.py` that shadowed the connector's own.
- **L-2** — give `Target` a uniform `add_ip(ip, resource_ids=None)` signature and a `name` attribute, removing `isinstance` branching in the dispatch loop.
- **L-3** — match the CrowdSec allowlist name as an exact whitespace-delimited token instead of a substring.
- **L-5** — add an auth-exempt `/healthz` liveness route and point the Docker/compose health checks at it (a hung server now fails the check, not just a dead process).
- **L-6** — add `pyproject.toml` (ruff config) and `SECURITY.md`. `target-version` is intentionally left at ruff's default; pinning `py314` makes `ruff format` rewrite `except (A, B):` into PEP 758 syntax that is a SyntaxError on the older interpreters used for local/CI test runs.

## Testing

- `pytest`: 194 passed (up from 185). New tests cover H-1 escaping, the H-3 secret gate (present / absent / wrong / unset), M-3 cache eviction, and `/healthz`.
- `ruff check .` and `ruff format --check .`: clean.

## Notes for reviewers

- **Validate against the test instance before production:** H-3, M-1/M-2, and M-3 touch the authorization chain, state persistence, and Pangolin API interaction.
- **Not included:** L-4 (CrowdSec CIDR containment) was intentionally deferred — current behavior is only mildly redundant (re-adding an IP already covered by a CIDR entry), never a security gap, and a fix would rework CrowdSec cache/membership semantics with real regression risk on an optional integration. A `LICENSE` was not added because the license choice is the owner's to make.
- **Release notes / labels:** this bundles multiple concerns; if per-category release notes matter, consider splitting into separate PRs (`security`, `bug`, `dependencies`, `chore`) or squashing under a single label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WRxYMxsoXWApwNZXcT9jf3)_