### PR TITLE
Refactor codebase for thread safety, CrowdSec cache optimization, and dead code removal

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,7 +18,6 @@ from crowdsec_connector import (
 )
 from pangolin_connector import (
     PangolinContext,
-    get_ip_set_for_resource_cached as pg_get_ip_set_for_resource_cached,
     ensure_ip_rule as pg_ensure_ip_rule,
     delete_ip_rule_if_created_by_us as pg_delete_ip_rule_if_created_by_us,
     list_org_resources as pg_list_org_resources,
@@ -260,12 +259,6 @@ if CROWDSEC_ENABLED:
     TARGETS.append(CrowdSecTarget())
 
 
-def _get_ip_set_for_resource_cached(rid: int):
-    """Return a set of IPs that currently have a rule for the resource.
-    Uses a 1h TTL cache to avoid frequent GET calls."""
-    ctx = make_pangolin_context()
-    return pg_get_ip_set_for_resource_cached(ctx, rid)
-
 
 # --------------------------
 # Target aggregation (extensibility point)
@@ -371,7 +364,7 @@ def cleanup_old_ips():
         with state_lock:
             rec = state.get(ip) or {}
             last_seen_str = rec.get("last_seen")
-            resources = rec.get("resources", {})
+            resources = dict(rec.get("resources", {}))
         try:
             last_seen = datetime.fromisoformat(last_seen_str) if last_seen_str else None
         except ValueError:

--- a/crowdsec_connector.py
+++ b/crowdsec_connector.py
@@ -312,7 +312,7 @@ def _get_crowdsec_ip_set_cached() -> set[str]:
     with _cache_lock:
         ts = _crowdsec_cache.get("ts", 0.0)
         ip_set = set(_crowdsec_cache.get("ip_set", set()))
-    if ip_set and (time.time() - ts) < CROWDSEC_CACHE_TTL_SECONDS:
+    if ts > 0.0 and (time.time() - ts) < CROWDSEC_CACHE_TTL_SECONDS:
         return ip_set
     return _crowdsec_refresh_allowlist_ip_set()
 
@@ -322,7 +322,11 @@ def _crowdsec_ip_known_or_refresh(ip: str) -> bool:
     ip_set = _get_crowdsec_ip_set_cached()
     if ip in ip_set:
         return True
-    # Not known -> force refresh from cscli once
+    # Not known -> force refresh from cscli once unless we just refreshed it
+    with _cache_lock:
+        last_refresh = _crowdsec_cache.get("ts", 0.0)
+    if (time.time() - last_refresh) < 5.0:
+        return False
     ip_set = _crowdsec_refresh_allowlist_ip_set()
     return ip in ip_set
 

--- a/pangolin_connector.py
+++ b/pangolin_connector.py
@@ -58,7 +58,7 @@ def get_ip_set_for_resource_cached(ctx: PangolinContext, rid: int) -> Set[str]:
     with ctx.state_lock:
         entry = ctx.rules_cache.get(rid)
         if entry and (now - entry.get("ts", 0) < ctx.rules_cache_ttl_seconds):
-            return entry.get("ip_set", set())
+            return set(entry.get("ip_set", set()))
 
     # Refresh from Pangolin
     print(f"[pangolin] refreshing rules for resource {rid}")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -104,13 +104,16 @@ def test_rules_cache_uses_cache(monkeypatch, app_module):
 
     monkeypatch.setattr(app, "http_json", fake_http_json)
 
+    from pangolin_connector import get_ip_set_for_resource_cached
+    ctx = app.make_pangolin_context()
+
     # First call should hit http_json
-    s1 = app._get_ip_set_for_resource_cached(5)
+    s1 = get_ip_set_for_resource_cached(ctx, 5)
     assert "9.8.7.6" in s1
     assert calls["count"] == 1
 
     # Second call within TTL should use cache
-    s2 = app._get_ip_set_for_resource_cached(5)
+    s2 = get_ip_set_for_resource_cached(ctx, 5)
     assert "1.2.3.4" in s2
     assert calls["count"] == 1
 


### PR DESCRIPTION
`Refactor codebase for thread safety, CrowdSec cache optimization, and dead code removal`

- Implement thread-safe copying of resources dictionary in app.py during cleanup to prevent concurrency race conditions with incoming web request threads.

- Implement thread-safe copying of the cached IP set in pangolin_connector.py to prevent concurrent read/write race conditions.

- Fix CrowdSec empty allowlist caching bug where empty allowlists bypassed cache TTL and spawned shell commands on every request.

- Optimize CrowdSec checking flow to prevent back-to-back duplicate CLI commands for new IP addresses.

- Remove the unused _get_ip_set_for_resource_cached wrapper and its import.

- Update the unit tests to call the connector methods directly.
