### PR TITLE
feat: support redirect and central link to new resources launcher

### DIFF
--- a/app.py
+++ b/app.py
@@ -65,6 +65,28 @@ DEBUG_LOG_HEADERS = os.getenv("DEBUG_LOG_HEADERS", "false").strip().lower() in (
     "yes",
     "on",
 )
+# Optional: redirect browser check-ins directly to Pangolin Resource Launcher (dashboard)
+REDIRECT_TO_LAUNCHER = os.getenv("REDIRECT_TO_LAUNCHER", "false").strip().lower() in (
+    "1",
+    "true",
+    "yes",
+    "on",
+)
+# Optional: explicitly override the Pangolin Resource Launcher dashboard URL.
+# If empty, it is automatically derived from PANGOLIN_URL and ORG_ID.
+PANGOLIN_DASHBOARD_URL = os.getenv("PANGOLIN_DASHBOARD_URL", "").strip().rstrip("/")
+if not PANGOLIN_DASHBOARD_URL and PANGOLIN_URL:
+    # Derive from PANGOLIN_URL (strip api/version suffixes and append ORG_ID if present)
+    _base = PANGOLIN_URL
+    for _suffix in ("/v1", "/v2", "/api"):
+        if _base.endswith(_suffix):
+            _base = _base[: -len(_suffix)]
+    _base = _base.rstrip("/")
+    if ORG_ID:
+        PANGOLIN_DASHBOARD_URL = f"{_base}/{ORG_ID}"
+    else:
+        PANGOLIN_DASHBOARD_URL = _base
+
 
 # Minimal 1x1 PNG (transparent) as bytes
 BANNER_PNG = base64.b64decode(
@@ -453,6 +475,8 @@ def _make_image_handler_context() -> dict:
         "banner_png": BANNER_PNG,
         "banner_gif": BANNER_GIF,
         "redact_headers_for_log": redact_headers_for_log,
+        "redirect_to_launcher": REDIRECT_TO_LAUNCHER,
+        "pangolin_dashboard_url": PANGOLIN_DASHBOARD_URL,
     }
 
 
@@ -547,7 +571,8 @@ def self_check():
         f"resources={RESOURCE_IDS} retention_minutes={RETENTION_MINUTES} "
         f"cleanup_interval_minutes={CLEANUP_INTERVAL_MINUTES} rule_priority={RULE_PRIORITY} "
         f"crowdsec={cs_status} update_endpoint_enabled={UPDATE_ENDPOINT_ENABLED} "
-        f"site_name={SITE_NAME!r}"
+        f"site_name={SITE_NAME!r} redirect_to_launcher={REDIRECT_TO_LAUNCHER} "
+        f"pangolin_dashboard_url={PANGOLIN_DASHBOARD_URL!r}"
     )
 
 

--- a/config.env.sample
+++ b/config.env.sample
@@ -60,3 +60,18 @@ PROXY_SHARED_SECRET=
 # Log every request's headers (Authorization/Proxy-Authorization redacted) for
 # debugging. Leave false in production.
 DEBUG_LOG_HEADERS=false
+
+# ---------------------------------------------------------------------------
+# Available Resources Dashboard (Resource Launcher) Integration
+# ---------------------------------------------------------------------------
+# Set to true to automatically redirect the user's browser to the Pangolin Resource
+# Launcher after a successful check-in. If check-in fails, redirection is bypassed
+# so errors are visible. Default is false.
+REDIRECT_TO_LAUNCHER=false
+
+# Explicitly override the user-facing Pangolin Resource Launcher (dashboard) URL.
+# If empty, this is derived automatically from PANGOLIN_URL by stripping any API path
+# suffixes (e.g. /v1, /api) and appending /ORG_ID (if ORG_ID is configured).
+# Example: https://pangolin.thecolefam.com/the-cole-fam
+PANGOLIN_DASHBOARD_URL=
+

--- a/request_handler.py
+++ b/request_handler.py
@@ -73,6 +73,7 @@ def _build_checkin_html(
     crowdsec_enabled: bool,
     resources: list | None = None,
     site_name: str = "",
+    dashboard_url: str = "",
 ) -> str:
     try:
         seen_dt = datetime.fromisoformat(last_seen)
@@ -123,6 +124,38 @@ def _build_checkin_html(
 
     resource_rows = _render_resource_rows(resources or [], overall_ok)
 
+    # Build the central launcher button if dashboard_url is set and overall_ok is True
+    launcher_row = ""
+    if overall_ok and dashboard_url:
+        safe_url = html.escape(dashboard_url, quote=True)
+        launcher_row = (
+            f'      <a class="access-link launcher-link" href="{safe_url}" target="_blank" rel="noopener noreferrer" style="border-color: var(--accent); background: var(--accent-hover-bg); margin-bottom: 8px;">\n'
+            '        <span class="access-link-left">\n'
+            '          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="flex-shrink:0; color: var(--accent);">'
+            '<path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>'
+            '<polyline points="9 22 9 12 15 12 15 22"/>'
+            "</svg>\n"
+            '          <span class="access-link-text">\n'
+            '            <span class="access-link-label" style="font-weight:600;">Open Resource Launcher</span>\n'
+            f'            <span class="access-link-url" style="color: var(--text); opacity: 0.85;">{safe_url}</span>\n'
+            "          </span>\n"
+            "        </span>\n"
+            '        <svg class="access-link-arrow" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="color: var(--accent);">'
+            '<line x1="5" y1="12" x2="19" y2="12"/>'
+            '<polyline points="12 5 19 12 12 19"/>'
+            "</svg>\n"
+            "      </a>"
+        )
+
+    # Combine launcher row and resource rows
+    combined_rows = []
+    if launcher_row:
+        combined_rows.append(launcher_row)
+    if resource_rows:
+        combined_rows.append(resource_rows)
+
+    combined_html = "\n".join(combined_rows)
+
     bookmark_html = (
         (
             '  <button class="bookmark-btn" onclick="bookmarkPage()">\n'
@@ -145,9 +178,9 @@ def _build_checkin_html(
         else ""
     )
 
-    if resource_rows:
+    if combined_html:
         actions_section = (
-            '    <div class="action-list">\n' + resource_rows + "\n    </div>\n"
+            '    <div class="action-list">\n' + combined_html + "\n    </div>\n"
             '    <hr class="section-divider">'
         )
     else:
@@ -433,6 +466,28 @@ def create_image_request_handler(ctx: dict):
                     }
 
                 if self._wants_html():
+                    pangolin_ok = update_results.get("pangolin", {}).get("ok", False)
+                    crowdsec_ok = update_results.get("crowdsec", {}).get("ok", False)
+                    crowdsec_enabled = ctx.get("crowdsec_enabled", False)
+                    success = pangolin_ok and (not crowdsec_enabled or crowdsec_ok)
+
+                    if (
+                        ctx.get("redirect_to_launcher")
+                        and success
+                        and ctx.get("pangolin_dashboard_url")
+                    ):
+                        self.send_response(302)
+                        self.send_header("Location", ctx["pangolin_dashboard_url"])
+                        self.send_header(
+                            "Cache-Control",
+                            "no-store, no-cache, must-revalidate, max-age=0",
+                        )
+                        self.send_header("Pragma", "no-cache")
+                        self.send_header("Expires", "0")
+                        self._send_security_headers()
+                        self.end_headers()
+                        return
+
                     self._send_html(
                         200,
                         _build_checkin_html(
@@ -443,6 +498,7 @@ def create_image_request_handler(ctx: dict):
                             crowdsec_enabled=ctx.get("crowdsec_enabled", False),
                             resources=update_results.get("resources", []),
                             site_name=ctx.get("site_name", ""),
+                            dashboard_url=ctx.get("pangolin_dashboard_url", ""),
                         ),
                     )
                 else:
@@ -522,6 +578,28 @@ def create_image_request_handler(ctx: dict):
 
             # Browser gets the HTML page; everything else gets the transparent image
             if self._wants_html():
+                pangolin_ok = results.get("pangolin", {}).get("ok", False)
+                crowdsec_ok = results.get("crowdsec", {}).get("ok", False)
+                crowdsec_enabled = ctx.get("crowdsec_enabled", False)
+                success = pangolin_ok and (not crowdsec_enabled or crowdsec_ok)
+
+                if (
+                    ctx.get("redirect_to_launcher")
+                    and success
+                    and ctx.get("pangolin_dashboard_url")
+                ):
+                    self.send_response(302)
+                    self.send_header("Location", ctx["pangolin_dashboard_url"])
+                    self.send_header(
+                        "Cache-Control",
+                        "no-store, no-cache, must-revalidate, max-age=0",
+                    )
+                    self.send_header("Pragma", "no-cache")
+                    self.send_header("Expires", "0")
+                    self._send_security_headers()
+                    self.end_headers()
+                    return
+
                 self._send_html(
                     200,
                     _build_checkin_html(
@@ -532,6 +610,7 @@ def create_image_request_handler(ctx: dict):
                         crowdsec_enabled=ctx.get("crowdsec_enabled", False),
                         resources=results.get("resources", []),
                         site_name=ctx.get("site_name", ""),
+                        dashboard_url=ctx.get("pangolin_dashboard_url", ""),
                     ),
                 )
             else:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2768,3 +2768,142 @@ def test_rate_limit_cache_keyed_by_ip_and_user(app_module, monkeypatch):
     res3 = app.add_ip_to_targets("1.1.1.1", remote_user="user-1")
     assert res3["pangolin"]["ok"] is True
     assert len(calls) == 2  # No new call
+
+
+def test_dashboard_url_derivation(monkeypatch):
+    import importlib
+    import app as _app
+
+    # Test 1: Both PANGOLIN_URL and ORG_ID set, no trailing slash/v1
+    monkeypatch.setenv("PANGOLIN_URL", "https://pangolin.thecolefam.com")
+    monkeypatch.setenv("ORG_ID", "the-cole-fam")
+    monkeypatch.setenv("PANGOLIN_DASHBOARD_URL", "")
+    app = importlib.reload(_app)
+    assert app.PANGOLIN_DASHBOARD_URL == "https://pangolin.thecolefam.com/the-cole-fam"
+
+    # Test 2: PANGOLIN_URL has /v1, ORG_ID set
+    monkeypatch.setenv("PANGOLIN_URL", "https://pangolin.thecolefam.com/v1")
+    monkeypatch.setenv("ORG_ID", "the-cole-fam")
+    monkeypatch.setenv("PANGOLIN_DASHBOARD_URL", "")
+    app = importlib.reload(_app)
+    assert app.PANGOLIN_DASHBOARD_URL == "https://pangolin.thecolefam.com/the-cole-fam"
+
+    # Test 3: PANGOLIN_URL has trailing slash and /api
+    monkeypatch.setenv("PANGOLIN_URL", "https://api.yourdomain.com/api/")
+    monkeypatch.setenv("ORG_ID", "myorg")
+    monkeypatch.setenv("PANGOLIN_DASHBOARD_URL", "")
+    app = importlib.reload(_app)
+    assert app.PANGOLIN_DASHBOARD_URL == "https://api.yourdomain.com/myorg"
+
+    # Test 4: Explicit PANGOLIN_DASHBOARD_URL override
+    monkeypatch.setenv("PANGOLIN_URL", "https://pangolin.thecolefam.com/v1")
+    monkeypatch.setenv("ORG_ID", "the-cole-fam")
+    monkeypatch.setenv("PANGOLIN_DASHBOARD_URL", "https://custom-dashboard.com/subpath")
+    app = importlib.reload(_app)
+    assert app.PANGOLIN_DASHBOARD_URL == "https://custom-dashboard.com/subpath"
+
+
+def test_dashboard_redirection_and_button(temp_state_file, monkeypatch):
+    import importlib
+    import app as _app
+
+    test_ip = "1.2.3.4"
+
+    # Scenario 1: REDIRECT_TO_LAUNCHER = False (default), check-in succeeds.
+    # Should return 200 OK and HTML containing the Resource Launcher button and resource links.
+    monkeypatch.setenv("PANGOLIN_TOKEN", "fake-token")
+    monkeypatch.setenv("ORG_ID", "the-cole-fam")
+    monkeypatch.setenv("PANGOLIN_URL", "https://pangolin.thecolefam.com")
+    monkeypatch.setenv("REDIRECT_TO_LAUNCHER", "false")
+    monkeypatch.setenv("LISTEN_PORT", "0")
+    monkeypatch.setenv("STATE_FILE", temp_state_file)
+
+    app = importlib.reload(_app)
+
+    state_mock = {"succeed": True}
+
+    def fake_filter(ctx, org_id, username):
+        if state_mock["succeed"]:
+            return [
+                {"resourceId": 5, "name": "Res", "fullDomain": "d.com", "ssl": True}
+            ]
+        else:
+            raise RuntimeError("Authorization failed")
+
+    monkeypatch.setattr(app, "pg_filter_resources_for_user", fake_filter)
+
+    class FakeTarget:
+        name = "pangolin"
+
+        def add_ip(self, ip, resource_ids=None):
+            pass
+
+        def ensure_ready(self):
+            pass
+
+    monkeypatch.setattr(app, "TARGETS", [FakeTarget()])
+
+    with start_server(app.ImageRequestHandler) as (httpd, port):
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+        headers = {
+            "X-Real-IP": test_ip,
+            "Remote-User": "alice",
+            "Accept": "text/html",
+        }
+        conn.request("GET", "/check.png", headers=headers)
+        resp = conn.getcall = conn.getresponse()
+        data = resp.read().decode("utf-8")
+        assert resp.status == 200
+        assert "Open Resource Launcher" in data
+        assert "https://pangolin.thecolefam.com/the-cole-fam" in data
+        assert "Open Res" in data
+
+    # Scenario 2: REDIRECT_TO_LAUNCHER = True, check-in succeeds.
+    # Should redirect with 302 to the dashboard URL.
+    monkeypatch.setenv("REDIRECT_TO_LAUNCHER", "true")
+    app = importlib.reload(_app)
+
+    monkeypatch.setattr(app, "pg_filter_resources_for_user", fake_filter)
+    monkeypatch.setattr(app, "TARGETS", [FakeTarget()])
+
+    with start_server(app.ImageRequestHandler) as (httpd, port):
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+        headers = {
+            "X-Real-IP": test_ip,
+            "Remote-User": "alice",
+            "Accept": "text/html",
+        }
+        conn.request("GET", "/check.png", headers=headers)
+        resp = conn.getresponse()
+        _ = resp.read()
+        assert resp.status == 302
+        assert (
+            resp.getheader("Location") == "https://pangolin.thecolefam.com/the-cole-fam"
+        )
+
+    # 3) REDIRECT_TO_LAUNCHER = True, check-in fails.
+    # Should NOT redirect, should return 200 OK with details page.
+    state_mock["succeed"] = False
+    with app._api_rate_limit_lock:
+        app._api_rate_limit.clear()
+
+    with start_server(app.ImageRequestHandler) as (httpd, port):
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+        headers = {
+            "X-Real-IP": test_ip,
+            "Remote-User": "alice",
+            "Accept": "text/html",
+        }
+        conn.request("GET", "/check.png", headers=headers)
+        resp = conn.getcall = (
+            conn.getcall
+            if hasattr(conn, "getcall")
+            else conn.getcall
+            if hasattr(conn, "getcall")
+            else conn.getresponse
+        )
+        resp = resp()
+        data = resp.read().decode("utf-8")
+        assert resp.status == 200
+        assert "Authorization failed" in data
+        assert "Open Resource Launcher" not in data


### PR DESCRIPTION
`feat: support redirect and central link to new resources launcher`

- Support optional browser redirection to the Pangolin Resource Launcher (SSO dashboard) upon successful check-in via the new `REDIRECT_TO_LAUNCHER` environment variable.

- Derive the launcher dashboard URL automatically from `PANGOLIN_URL` by stripping API path suffixes, with an optional explicit override via `PANGOLIN_DASHBOARD_URL`.

- Prepend a prominent "Open Resource Launcher" button to the check-in status page, maintaining the individual resource links below it as quick links.

- Add unit and integration tests covering the new redirection, bypass on failure, and HTML button rendering logic.
