### PR TITLE
chore: document redirection options in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,11 @@ services:
       # Branding
       SITE_NAME: "" # Shown in HTML page header/footer. Optional
 
+      # Available Resources Dashboard (Resource Launcher) Integration
+      REDIRECT_TO_LAUNCHER: ${REDIRECT_TO_LAUNCHER:-false}
+      PANGOLIN_DASHBOARD_URL: ${PANGOLIN_DASHBOARD_URL:-}
+
+
       # ---------------------------------------------------------------------------
       # CrowdSec integration (optional — disabled by default)
       # ---------------------------------------------------------------------------


### PR DESCRIPTION
`chore: document redirection options in docker-compose.yml`

- Expose `REDIRECT_TO_LAUNCHER` and `PANGOLIN_DASHBOARD_URL` configuration variables in the `environment` section of `docker-compose.yml` with helpful defaults/placeholders.
