### PR TITLE
feat: support delayed browser redirection with visual countdown

### DIFF
--- a/app.py
+++ b/app.py
@@ -72,6 +72,11 @@ REDIRECT_TO_LAUNCHER = os.getenv("REDIRECT_TO_LAUNCHER", "false").strip().lower(
     "yes",
     "on",
 )
+# Optional: delay redirect by X seconds. Set to 0 for immediate redirect. Default is 3.
+try:
+    REDIRECT_DELAY_SECONDS = int(os.getenv("REDIRECT_DELAY_SECONDS", "3"))
+except ValueError:
+    REDIRECT_DELAY_SECONDS = 3
 # Optional: explicitly override the Pangolin Resource Launcher dashboard URL.
 # If empty, it is automatically derived from PANGOLIN_URL and ORG_ID.
 PANGOLIN_DASHBOARD_URL = os.getenv("PANGOLIN_DASHBOARD_URL", "").strip().rstrip("/")
@@ -476,6 +481,7 @@ def _make_image_handler_context() -> dict:
         "banner_gif": BANNER_GIF,
         "redact_headers_for_log": redact_headers_for_log,
         "redirect_to_launcher": REDIRECT_TO_LAUNCHER,
+        "redirect_delay_seconds": REDIRECT_DELAY_SECONDS,
         "pangolin_dashboard_url": PANGOLIN_DASHBOARD_URL,
     }
 
@@ -572,6 +578,7 @@ def self_check():
         f"cleanup_interval_minutes={CLEANUP_INTERVAL_MINUTES} rule_priority={RULE_PRIORITY} "
         f"crowdsec={cs_status} update_endpoint_enabled={UPDATE_ENDPOINT_ENABLED} "
         f"site_name={SITE_NAME!r} redirect_to_launcher={REDIRECT_TO_LAUNCHER} "
+        f"redirect_delay_seconds={REDIRECT_DELAY_SECONDS} "
         f"pangolin_dashboard_url={PANGOLIN_DASHBOARD_URL!r}"
     )
 

--- a/config.env.sample
+++ b/config.env.sample
@@ -69,9 +69,17 @@ DEBUG_LOG_HEADERS=false
 # so errors are visible. Default is false.
 REDIRECT_TO_LAUNCHER=false
 
+# Number of seconds to display the check-in success page before redirecting.
+# If set to 0, the redirection is immediate (via HTTP 302 redirect).
+# If set to > 0 (e.g., 3), the browser displays the success page showing details and
+# a visual countdown timer, then redirects automatically. The individual app list
+# is hidden during delayed redirects since they are going to the launcher. Default is 3.
+REDIRECT_DELAY_SECONDS=3
+
 # Explicitly override the user-facing Pangolin Resource Launcher (dashboard) URL.
 # If empty, this is derived automatically from PANGOLIN_URL by stripping any API path
 # suffixes (e.g. /v1, /api) and appending /ORG_ID (if ORG_ID is configured).
 # Example: https://pangolin.thecolefam.com/the-cole-fam
 PANGOLIN_DASHBOARD_URL=
+
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,9 @@ services:
 
       # Available Resources Dashboard (Resource Launcher) Integration
       REDIRECT_TO_LAUNCHER: ${REDIRECT_TO_LAUNCHER:-false}
+      REDIRECT_DELAY_SECONDS: ${REDIRECT_DELAY_SECONDS:-3}
       PANGOLIN_DASHBOARD_URL: ${PANGOLIN_DASHBOARD_URL:-}
+
 
 
       # ---------------------------------------------------------------------------

--- a/request_handler.py
+++ b/request_handler.py
@@ -74,6 +74,8 @@ def _build_checkin_html(
     resources: list | None = None,
     site_name: str = "",
     dashboard_url: str = "",
+    redirect_to_launcher: bool = False,
+    redirect_delay_seconds: int = 3,
 ) -> str:
     try:
         seen_dt = datetime.fromisoformat(last_seen)
@@ -122,7 +124,41 @@ def _build_checkin_html(
 
     details_label = "Technical details" if overall_ok else "What went wrong?"
 
-    resource_rows = _render_resource_rows(resources or [], overall_ok)
+    # Only show individual allowed resources if not redirecting successfully
+    show_individual_resources = not (redirect_to_launcher and overall_ok)
+    resource_rows = ""
+    if show_individual_resources:
+        resource_rows = _render_resource_rows(resources or [], overall_ok)
+
+    # Build the redirection banner and inline script if redirecting on success
+    redirect_banner_html = ""
+    if (
+        overall_ok
+        and redirect_to_launcher
+        and dashboard_url
+        and redirect_delay_seconds > 0
+    ):
+        safe_url = html.escape(dashboard_url, quote=True)
+        redirect_banner_html = (
+            f'      <div class="redirect-banner" style="background: var(--accent-hover-bg); border: 1px solid var(--accent); padding: 12px 16px; border-radius: calc(var(--radius) - 2px); margin-bottom: 12px; font-size: 13px; text-align: center; color: var(--text);">\n'
+            f'        Redirecting to Resource Launcher in <strong id="countdown">{redirect_delay_seconds}</strong> seconds...\n'
+            "      </div>\n"
+            "      <script>\n"
+            "        (function() {\n"
+            f"          var delay = {redirect_delay_seconds};\n"
+            f'          var url = "{safe_url}";\n'
+            "          var interval = setInterval(function() {\n"
+            "            delay--;\n"
+            '            var el = document.getElementById("countdown");\n'
+            "            if (el) el.innerText = delay;\n"
+            "            if (delay <= 0) {\n"
+            "              clearInterval(interval);\n"
+            "              window.location.href = url;\n"
+            "            }\n"
+            "          }, 1000);\n"
+            "        })();\n"
+            "      </script>"
+        )
 
     # Build the central launcher button if dashboard_url is set and overall_ok is True
     launcher_row = ""
@@ -149,6 +185,8 @@ def _build_checkin_html(
 
     # Combine launcher row and resource rows
     combined_rows = []
+    if redirect_banner_html:
+        combined_rows.append(redirect_banner_html)
     if launcher_row:
         combined_rows.append(launcher_row)
     if resource_rows:
@@ -471,10 +509,14 @@ def create_image_request_handler(ctx: dict):
                     crowdsec_enabled = ctx.get("crowdsec_enabled", False)
                     success = pangolin_ok and (not crowdsec_enabled or crowdsec_ok)
 
+                    redirect_enabled = ctx.get("redirect_to_launcher", False)
+                    redirect_delay = ctx.get("redirect_delay_seconds", 3)
+
                     if (
-                        ctx.get("redirect_to_launcher")
+                        redirect_enabled
                         and success
                         and ctx.get("pangolin_dashboard_url")
+                        and redirect_delay == 0
                     ):
                         self.send_response(302)
                         self.send_header("Location", ctx["pangolin_dashboard_url"])
@@ -499,6 +541,8 @@ def create_image_request_handler(ctx: dict):
                             resources=update_results.get("resources", []),
                             site_name=ctx.get("site_name", ""),
                             dashboard_url=ctx.get("pangolin_dashboard_url", ""),
+                            redirect_to_launcher=redirect_enabled,
+                            redirect_delay_seconds=redirect_delay,
                         ),
                     )
                 else:
@@ -583,10 +627,14 @@ def create_image_request_handler(ctx: dict):
                 crowdsec_enabled = ctx.get("crowdsec_enabled", False)
                 success = pangolin_ok and (not crowdsec_enabled or crowdsec_ok)
 
+                redirect_enabled = ctx.get("redirect_to_launcher", False)
+                redirect_delay = ctx.get("redirect_delay_seconds", 3)
+
                 if (
-                    ctx.get("redirect_to_launcher")
+                    redirect_enabled
                     and success
                     and ctx.get("pangolin_dashboard_url")
+                    and redirect_delay == 0
                 ):
                     self.send_response(302)
                     self.send_header("Location", ctx["pangolin_dashboard_url"])
@@ -611,6 +659,8 @@ def create_image_request_handler(ctx: dict):
                         resources=results.get("resources", []),
                         site_name=ctx.get("site_name", ""),
                         dashboard_url=ctx.get("pangolin_dashboard_url", ""),
+                        redirect_to_launcher=redirect_enabled,
+                        redirect_delay_seconds=redirect_delay,
                     ),
                 )
             else:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2815,6 +2815,7 @@ def test_dashboard_redirection_and_button(temp_state_file, monkeypatch):
     monkeypatch.setenv("ORG_ID", "the-cole-fam")
     monkeypatch.setenv("PANGOLIN_URL", "https://pangolin.thecolefam.com")
     monkeypatch.setenv("REDIRECT_TO_LAUNCHER", "false")
+    monkeypatch.setenv("REDIRECT_DELAY_SECONDS", "3")
     monkeypatch.setenv("LISTEN_PORT", "0")
     monkeypatch.setenv("STATE_FILE", temp_state_file)
 
@@ -2825,7 +2826,12 @@ def test_dashboard_redirection_and_button(temp_state_file, monkeypatch):
     def fake_filter(ctx, org_id, username):
         if state_mock["succeed"]:
             return [
-                {"resourceId": 5, "name": "Res", "fullDomain": "d.com", "ssl": True}
+                {
+                    "resourceId": 5,
+                    "name": "Jellyfin",
+                    "fullDomain": "d.com",
+                    "ssl": True,
+                }
             ]
         else:
             raise RuntimeError("Authorization failed")
@@ -2851,16 +2857,17 @@ def test_dashboard_redirection_and_button(temp_state_file, monkeypatch):
             "Accept": "text/html",
         }
         conn.request("GET", "/check.png", headers=headers)
-        resp = conn.getcall = conn.getresponse()
+        resp = conn.getresponse()
         data = resp.read().decode("utf-8")
         assert resp.status == 200
         assert "Open Resource Launcher" in data
         assert "https://pangolin.thecolefam.com/the-cole-fam" in data
-        assert "Open Res" in data
+        assert "Open Jellyfin" in data
 
-    # Scenario 2: REDIRECT_TO_LAUNCHER = True, check-in succeeds.
-    # Should redirect with 302 to the dashboard URL.
+    # Scenario 2a: REDIRECT_TO_LAUNCHER = True, REDIRECT_DELAY_SECONDS = 0, check-in succeeds.
+    # Should redirect immediately with 302 to the dashboard URL.
     monkeypatch.setenv("REDIRECT_TO_LAUNCHER", "true")
+    monkeypatch.setenv("REDIRECT_DELAY_SECONDS", "0")
     app = importlib.reload(_app)
 
     monkeypatch.setattr(app, "pg_filter_resources_for_user", fake_filter)
@@ -2881,7 +2888,34 @@ def test_dashboard_redirection_and_button(temp_state_file, monkeypatch):
             resp.getheader("Location") == "https://pangolin.thecolefam.com/the-cole-fam"
         )
 
-    # 3) REDIRECT_TO_LAUNCHER = True, check-in fails.
+    # Scenario 2b: REDIRECT_TO_LAUNCHER = True, REDIRECT_DELAY_SECONDS = 3, check-in succeeds.
+    # Should return 200 OK with redirection notice, countdown script, launcher button,
+    # but NO individual resource links (Open Jellyfin).
+    monkeypatch.setenv("REDIRECT_TO_LAUNCHER", "true")
+    monkeypatch.setenv("REDIRECT_DELAY_SECONDS", "3")
+    app = importlib.reload(_app)
+
+    monkeypatch.setattr(app, "pg_filter_resources_for_user", fake_filter)
+    monkeypatch.setattr(app, "TARGETS", [FakeTarget()])
+
+    with start_server(app.ImageRequestHandler) as (httpd, port):
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+        headers = {
+            "X-Real-IP": test_ip,
+            "Remote-User": "alice",
+            "Accept": "text/html",
+        }
+        conn.request("GET", "/check.png", headers=headers)
+        resp = conn.getresponse()
+        data = resp.read().decode("utf-8")
+        assert resp.status == 200
+        assert "Redirecting to Resource Launcher in" in data
+        assert "countdown" in data
+        assert "window.location.href" in data
+        assert "Open Resource Launcher" in data
+        assert "Open Jellyfin" not in data
+
+    # Scenario 3: REDIRECT_TO_LAUNCHER = True, check-in fails.
     # Should NOT redirect, should return 200 OK with details page.
     state_mock["succeed"] = False
     with app._api_rate_limit_lock:
@@ -2907,3 +2941,4 @@ def test_dashboard_redirection_and_button(temp_state_file, monkeypatch):
         assert resp.status == 200
         assert "Authorization failed" in data
         assert "Open Resource Launcher" not in data
+        assert "Redirecting to Resource Launcher" not in data


### PR DESCRIPTION
`feat: support delayed browser redirection with visual countdown`

- Implement delayed browser redirection using an environment variable `REDIRECT_DELAY_SECONDS` (defaults to 3 seconds).

- Show a real-time JavaScript countdown timer on the check-in success page before automatically redirecting the user.

- Hide the individual resource quick links when redirection is active on success to keep the UI clean, while keeping the manual "Open Resource Launcher" override button.

- Support immediate redirection (via HTTP 302) when `REDIRECT_DELAY_SECONDS` is set to 0.

- Update tests, compose configuration, and documentation templates.
