### PR TITLE
fix: bypass redirection if CrowdSec target fails

### DIFF
--- a/request_handler.py
+++ b/request_handler.py
@@ -91,6 +91,7 @@ def _build_checkin_html(
     crowdsec_ok = results.get("crowdsec", {}).get("ok", False)
     crowdsec_detail = results.get("crowdsec", {}).get("detail", "disabled")
     overall_ok = pangolin_ok
+    success = pangolin_ok and (not crowdsec_enabled or crowdsec_ok)
 
     dot_class = "status-dot" if overall_ok else "status-dot err"
     if overall_ok:
@@ -125,7 +126,7 @@ def _build_checkin_html(
     details_label = "Technical details" if overall_ok else "What went wrong?"
 
     # Only show individual allowed resources if not redirecting successfully
-    show_individual_resources = not (redirect_to_launcher and overall_ok)
+    show_individual_resources = not (redirect_to_launcher and success)
     resource_rows = ""
     if show_individual_resources:
         resource_rows = _render_resource_rows(resources or [], overall_ok)
@@ -133,7 +134,7 @@ def _build_checkin_html(
     # Build the redirection banner and inline script if redirecting on success
     redirect_banner_html = ""
     if (
-        overall_ok
+        success
         and redirect_to_launcher
         and dashboard_url
         and redirect_delay_seconds > 0

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2915,9 +2915,51 @@ def test_dashboard_redirection_and_button(temp_state_file, monkeypatch):
         assert "Open Resource Launcher" in data
         assert "Open Jellyfin" not in data
 
-    # Scenario 3: REDIRECT_TO_LAUNCHER = True, check-in fails.
+    # Scenario 3: REDIRECT_TO_LAUNCHER = True, check-in fails (Pangolin error).
     # Should NOT redirect, should return 200 OK with details page.
     state_mock["succeed"] = False
+    with app._api_rate_limit_lock:
+        app._api_rate_limit.clear()
+
+    with start_server(app.ImageRequestHandler) as (httpd, port):
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+        headers = {
+            "X-Real-IP": test_ip,
+            "Remote-User": "alice",
+            "Accept": "text/html",
+        }
+        conn.request("GET", "/check.png", headers=headers)
+        resp = conn.getresponse()
+        data = resp.read().decode("utf-8")
+        assert resp.status == 200
+        assert "Authorization failed" in data
+        assert "Open Resource Launcher" not in data
+        assert "Redirecting to Resource Launcher" not in data
+
+    # Scenario 4: REDIRECT_TO_LAUNCHER = True, Pangolin succeeds, but CrowdSec is enabled and fails.
+    # Should NOT redirect, should return 200 OK showing CrowdSec failure details.
+    state_mock["succeed"] = True
+    import crowdsec_connector
+
+    monkeypatch.setattr(crowdsec_connector, "CROWDSEC_ENABLED", True)
+    monkeypatch.setenv("CROWDSEC_ENABLED", "true")
+    monkeypatch.setenv("REDIRECT_TO_LAUNCHER", "true")
+    monkeypatch.setenv("REDIRECT_DELAY_SECONDS", "3")
+    app = importlib.reload(_app)
+
+    monkeypatch.setattr(app, "pg_filter_resources_for_user", fake_filter)
+
+    # Mock CrowdSec failure by letting CrowdSecTarget raise an error
+    class FailingCrowdSecTarget:
+        name = "crowdsec"
+
+        def add_ip(self, ip, resource_ids=None):
+            raise RuntimeError("crowdsec command failed")
+
+        def ensure_ready(self):
+            pass
+
+    monkeypatch.setattr(app, "TARGETS", [FakeTarget(), FailingCrowdSecTarget()])
     with app._api_rate_limit_lock:
         app._api_rate_limit.clear()
 
@@ -2939,6 +2981,5 @@ def test_dashboard_redirection_and_button(temp_state_file, monkeypatch):
         resp = resp()
         data = resp.read().decode("utf-8")
         assert resp.status == 200
-        assert "Authorization failed" in data
-        assert "Open Resource Launcher" not in data
+        assert "crowdsec command failed" in data
         assert "Redirecting to Resource Launcher" not in data


### PR DESCRIPTION
`fix: bypass redirection if CrowdSec target fails`

- Bypass both immediate and delayed browser redirection if the CrowdSec target fails when enabled, ensuring that target error details remain visible on the check-in status page.

- Add an integration test case (Scenario 4) to verify that redirection is properly bypassed when CrowdSec allowlisting fails.
