### PR TITLE
fix: show warning dot and expand details on partial failure

### DIFF
--- a/request_handler.py
+++ b/request_handler.py
@@ -93,14 +93,31 @@ def _build_checkin_html(
     overall_ok = pangolin_ok
     success = pangolin_ok and (not crowdsec_enabled or crowdsec_ok)
 
-    dot_class = "status-dot" if overall_ok else "status-dot err"
-    if overall_ok:
+    # Determine status presentation (success, warning, or error)
+    if success:
+        dot_class = "status-dot"
         if site_name:
             hero = f"Access granted to <strong>{html.escape(site_name)}</strong>."
         else:
             hero = "Your IP address has <strong>access</strong>."
+        details_label = "Technical details"
+        details_expanded = "false"
+        details_open_class = ""
+    elif pangolin_ok:
+        dot_class = "status-dot warn"
+        if site_name:
+            hero = f"Access granted to <strong>{html.escape(site_name)}</strong>, but security rules failed."
+        else:
+            hero = "Access granted, but security rules failed."
+        details_label = "What went wrong?"
+        details_expanded = "true"
+        details_open_class = "open"
     else:
+        dot_class = "status-dot err"
         hero = "Access may not work right now."
+        details_label = "What went wrong?"
+        details_expanded = "true"
+        details_open_class = "open"
 
     pangolin_badge = (
         '<span class="badge ok">Added</span>'
@@ -244,6 +261,8 @@ def _build_checkin_html(
             "RETENTION_LABEL": _format_retention(retention_minutes),
             "RETENTION_MINUTES": str(retention_minutes),
             "DETAILS_LABEL": details_label,
+            "DETAILS_EXPANDED": details_expanded,
+            "DETAILS_OPEN_CLASS": details_open_class,
             "DETAILS_IP": ip,
             "PANGOLIN_DETAIL_CLASS": pangolin_detail_class,
             "PANGOLIN_DETAIL": html.escape(str(pangolin_detail)),

--- a/templates/checkin.html
+++ b/templates/checkin.html
@@ -74,6 +74,8 @@
     animation: pulse 2.4s ease-in-out infinite;
   }
   .status-dot.err { background: var(--err); box-shadow: 0 0 0 3px var(--err-dim); animation: none; }
+  .status-dot.warn { background: var(--warn); box-shadow: 0 0 0 3px var(--warn-dim); animation: none; }
+
   @keyframes pulse {
     0%,100% { box-shadow: 0 0 0 3px var(--status-ok-dim); }
     50%      { box-shadow: 0 0 0 6px var(--status-ok-dim); }
@@ -170,7 +172,7 @@
     <p class="hero">{{HERO}}</p>
 {{ACTIONS_SECTION}}
 {{BOOKMARK_SECTION}}
-    <button class="details-toggle" aria-expanded="false" onclick="toggleDetails('details', this)">
+    <button class="details-toggle" aria-expanded="{{DETAILS_EXPANDED}}" onclick="toggleDetails('details', this)">
       <span class="access-link-left">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="flex-shrink:0;"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
         <span class="access-link-text">
@@ -180,7 +182,7 @@
       </span>
       <svg class="access-link-arrow" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
     </button>
-    <div class="details-body" id="details">
+    <div class="details-body {{DETAILS_OPEN_CLASS}}" id="details">
       <div class="ip-row">
         <span class="ip-label">Your IP</span>
         <span class="ip-value">{{IP}}</span>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2339,7 +2339,7 @@ _LAST_SEEN_ISO = "2025-01-01T00:00:00+00:00"
 
 
 def test_checkin_html_success_hero_and_dot():
-    """Success path → access hero text and green (non-error) dot class."""
+    """Success path → access hero text and green dot class, details collapsed."""
     from request_handler import _build_checkin_html
 
     page = _build_checkin_html(
@@ -2352,10 +2352,34 @@ def test_checkin_html_success_hero_and_dot():
     assert "<strong>access</strong>" in page
     assert 'class="status-dot">' in page
     assert 'class="status-dot err">' not in page
+    assert 'class="status-dot warn">' not in page
+    assert 'aria-expanded="false"' in page
+    assert 'class="details-body "' in page
+
+
+def test_checkin_html_warning_hero_and_dot():
+    """Warning path (partial failure) → warning hero, warn dot class, details expanded."""
+    from request_handler import _build_checkin_html
+
+    partial_results = {
+        "pangolin": {"ok": True, "detail": "ok"},
+        "crowdsec": {"ok": False, "detail": "failed"},
+    }
+    page = _build_checkin_html(
+        ip="1.2.3.4",
+        results=partial_results,
+        retention_minutes=1440,
+        last_seen=_LAST_SEEN_ISO,
+        crowdsec_enabled=True,
+    )
+    assert "but security rules failed" in page
+    assert 'class="status-dot warn">' in page
+    assert 'aria-expanded="true"' in page
+    assert 'class="details-body open"' in page
 
 
 def test_checkin_html_failure_hero_and_dot():
-    """Failure path → 'may not work' hero text and error dot class."""
+    """Failure path → 'may not work' hero text, error dot class, details expanded."""
     from request_handler import _build_checkin_html
 
     page = _build_checkin_html(
@@ -2367,6 +2391,8 @@ def test_checkin_html_failure_hero_and_dot():
     )
     assert "may not work" in page
     assert 'class="status-dot err">' in page
+    assert 'aria-expanded="true"' in page
+    assert 'class="details-body open"' in page
 
 
 def test_checkin_html_crowdsec_disabled_badge():


### PR DESCRIPTION
`fix: show yellow warning dot and expand details automatically on CrowdSec partial failure`

- Introduce a new `.status-dot.warn` amber/yellow styling class to the check-in status page.

- Distinguish between perfect success (both Pangolin and CrowdSec pass), partial failure (Pangolin succeeds but CrowdSec fails), and total failure (Pangolin fails).

- On partial failure, display a yellow status dot, present a "but security rules failed" warning message, and automatically expand the "Technical details" drawer so that users immediately see the red "FAILED" badge and corresponding error details.

- Add and expand unit tests for HTML rendering under success, warning, and failure states.
