### PR TITLE
fix: only show Open Resource Launcher button if redirection is enabled

### DIFF
--- a/request_handler.py
+++ b/request_handler.py
@@ -178,9 +178,9 @@ def _build_checkin_html(
             "      </script>"
         )
 
-    # Build the central launcher button if dashboard_url is set and overall_ok is True
+    # Build the central launcher button if dashboard_url is set, redirection is enabled, and overall_ok is True
     launcher_row = ""
-    if overall_ok and dashboard_url:
+    if overall_ok and dashboard_url and redirect_to_launcher:
         safe_url = html.escape(dashboard_url, quote=True)
         launcher_row = (
             f'      <a class="access-link launcher-link" href="{safe_url}" target="_blank" rel="noopener noreferrer" style="border-color: var(--accent); background: var(--accent-hover-bg); margin-bottom: 8px;">\n'

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2886,8 +2886,8 @@ def test_dashboard_redirection_and_button(temp_state_file, monkeypatch):
         resp = conn.getresponse()
         data = resp.read().decode("utf-8")
         assert resp.status == 200
-        assert "Open Resource Launcher" in data
-        assert "https://pangolin.thecolefam.com/the-cole-fam" in data
+        assert "Open Resource Launcher" not in data
+        assert "https://pangolin.thecolefam.com/the-cole-fam" not in data
         assert "Open Jellyfin" in data
 
     # Scenario 2a: REDIRECT_TO_LAUNCHER = True, REDIRECT_DELAY_SECONDS = 0, check-in succeeds.


### PR DESCRIPTION
`fix: only show Open Resource Launcher button if redirection is enabled`

- Only render the "Open Resource Launcher" link button on the check-in status page if redirection is enabled (`REDIRECT_TO_LAUNCHER` is True).

- If redirection is disabled (False), only display the individual allowed resource links (e.g. "Open Jellyfin").

- Update integration test suite (Scenario 1) assertions to verify the "Open Resource Launcher" button and the dashboard link are omitted when redirection is disabled.
