### PR TITLE
security: harden and minimize container runtime

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,7 @@
-.git
-.gitignore
-.env
-.env.*
-__pycache__
-*.pyc
-*.pyo
-.pytest_cache
-.ruff_cache
-tests/
-requirements.txt
+# Send only runtime sources to the builder. This keeps local metadata, secrets,
+# tests, documentation, and developer tooling out of the build context entirely.
+*
+!*.py
+!docker-entrypoint.sh
+!templates/
+!templates/*.html

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ pangolin-ip-rule-manager/
 ├── pangolin_connector.py    # All Pangolin API interaction: PangolinContext dataclass, retry logic
 ├── crowdsec_connector.py    # CrowdSec integration via cscli subprocess
 ├── requirements.txt         # Dev dependencies (pytest, ruff) — not used in the runtime image
-├── Dockerfile               # python:3.14-alpine; docker-cli included for CrowdSec integration via docker exec
+├── Dockerfile               # Trimmed Python 3.14 Alpine runtime; docker-cli included for CrowdSec via docker exec
 ├── docker-compose.yml       # Reference compose file — actual deployment uses Portainer
 ├── config.env.sample        # Every environment variable with inline documentation
 └── tests/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,46 @@
-# Minimal Python stdlib-only image
-# Digest-pinned for reproducible builds; Dependabot (docker ecosystem) bumps it.
-FROM python:3.14-alpine@sha256:26730869004e2b9c4b9ad09cab8625e81d256d1ce97e72df5520e806b1709f92
+# syntax=docker/dockerfile:1
 
-# Install Docker CLI for optional CrowdSec integration via 'docker exec crowdsec cscli ...'
-RUN apk add --no-cache docker-cli
+# Start from the current patched Python 3.14 Alpine image. The digest is
+# multi-architecture and Dependabot keeps it current.
+FROM python:3.14.6-alpine3.24@sha256:26730869004e2b9c4b9ad09cab8625e81d256d1ce97e72df5520e806b1709f92 AS runtime-root
 
-ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
+# Keep the existing 100:101 identity stable so upgrades can read and write named
+# volumes created by earlier images. New named volumes inherit /data's ownership
+# and mode automatically; no host-side chown or chmod is needed.
+RUN apk add --no-cache docker-cli \
+    && addgroup -S -g 101 appgroup \
+    && adduser -S -D -H -h /nonexistent -s /sbin/nologin \
+        -u 100 -G appgroup appuser \
+    && mkdir -p /app/templates /data \
+    && chmod 0755 /app /app/templates \
+    && chown appuser:appgroup /data \
+    && chmod 0700 /data \
+    && rm -rf \
+        /usr/local/bin/idle* \
+        /usr/local/bin/pip* \
+        /usr/local/bin/pydoc* \
+        /usr/local/bin/python*-config \
+        /usr/local/include \
+        /usr/local/lib/pkgconfig \
+        /usr/local/lib/python3.14/config-* \
+        /usr/local/lib/python3.14/ensurepip \
+        /usr/local/lib/python3.14/idlelib \
+        /usr/local/lib/python3.14/site-packages \
+        /usr/local/lib/python3.14/tkinter \
+        /usr/local/lib/python3.14/turtledemo \
+        /usr/local/lib/python3.14/venv \
+        /usr/local/share/man
+
+# Flatten the prepared runtime into a clean final layer so removed Python
+# package-management and development files do not remain in lower image layers.
+FROM scratch
+COPY --from=runtime-root / /
+
+ENV PATH=/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONNOUSERSITE=1 \
+    PYTHONUNBUFFERED=1 \
+    HOME=/tmp
 
 # Operational defaults — PANGOLIN_URL, PANGOLIN_TOKEN, ORG_ID, and RESOURCE_IDS
 # are not set here; they must always be injected at runtime via your orchestrator
@@ -19,16 +53,12 @@ ENV RETENTION_MINUTES="1440" \
     RULES_CACHE_TTL_SECONDS="3600"
 
 WORKDIR /app
-# Copy all application modules (after refactor we have multiple .py files)
-COPY *.py /app/
-COPY templates/ /app/templates/
+# Application code is immutable at runtime and does not need write permission.
+COPY --chown=0:0 --chmod=0444 *.py /app/
+COPY --chown=0:0 --chmod=0444 templates/*.html /app/templates/
+COPY --chown=0:0 --chmod=0555 docker-entrypoint.sh /usr/local/bin/
 
-# Run as a non-root user; create the data directory first so the volume mount
-# inherits the correct ownership when the container starts.
-RUN addgroup -S appgroup && adduser -S appuser -G appgroup \
-    && mkdir -p /data && chown appuser:appgroup /data
-
-USER appuser
+USER appuser:appgroup
 
 EXPOSE 8080
 
@@ -36,4 +66,5 @@ EXPOSE 8080
 HEALTHCHECK --interval=60s --timeout=5s --start-period=15s --retries=3 \
     CMD wget -q -O - "http://127.0.0.1:${LISTEN_PORT}/healthz" || exit 1
 
-CMD ["python", "/app/app.py"]
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["python3", "/app/app.py"]

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ services:
       # ---------------------------------------------------------------------------
       # CrowdSec integration (optional — disabled by default)
       # ---------------------------------------------------------------------------
-      # Requires the Docker socket mounted read-only (see volumes below).
+      # Use the socket-proxy block in docker-compose.yml when enabling this.
       CROWDSEC_ENABLED: "false"
       CROWDSEC_ALLOWLIST_NAME: pangolin-ip-rule-manager
       CROWDSEC_CACHE_TTL_SECONDS: "3600"
@@ -176,8 +176,21 @@ services:
       # Optional endpoints (disabled by default)
       UPDATE_ENDPOINT_ENABLED: "false"
 
+    user: "100:101"
+    init: true
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,nodev,size=16m,mode=1777
+    pids_limit: 128
+    cpus: "0.5"
+    mem_limit: "256M"
+
     healthcheck:
-      test: ["CMD-SHELL", "pgrep -f app.py || exit 1"]
+      test: ["CMD-SHELL", "wget -q -O - http://127.0.0.1:$${LISTEN_PORT:-8080}/healthz || exit 1"]
       interval: 60s
       timeout: 5s
       retries: 3
@@ -185,16 +198,25 @@ services:
 
     volumes:
       - pangolin-ip-rule-manager-data:/data
-      # Required for CrowdSec integration. Mount the Docker socket read-only.
-      # - /var/run/docker.sock:/var/run/docker.sock:ro
 
     restart: unless-stopped
+
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
 volumes:
   pangolin-ip-rule-manager-data: {}
 ```
 
 Set environment variables via a `.env` file or directly in Portainer/your orchestration tool. **Never hardcode credentials.**
+
+The named volume is created and permissioned by Docker from the image metadata;
+the non-root entrypoint also tightens volumes from earlier releases to mode
+`0700` automatically. Fresh installs and upgrades require no host-side `chmod`,
+`chown`, directory creation, or other setup commands.
 
 ### Finding Your Resource IDs
 
@@ -300,7 +322,10 @@ Pangolin and CrowdSec are handled independently. If one succeeds and the other f
 
 ### Setup
 
-Runs `cscli` inside the CrowdSec container via `docker exec`. Requires mounting the Docker socket read-only and having `docker-cli` available in the image (it is).
+Runs `cscli` inside the CrowdSec container via `docker exec`; `docker-cli` is
+always available in the image. Use the socket-proxy block in the checked-in
+`docker-compose.yml` so the application receives only the Docker API operations
+needed for `exec`.
 
 ```yaml
 CROWDSEC_ENABLED: "true"
@@ -308,12 +333,10 @@ CROWDSEC_CMD_PREFIX: "docker exec crowdsec"
 CROWDSEC_CSCLI_BIN: cscli
 ```
 
-```yaml
-volumes:
-  - /var/run/docker.sock:/var/run/docker.sock:ro
-```
-
-> **Security note:** Docker socket access grants significant host-level capability. Mount the socket read-only (`:ro`) and ensure the container runs with the minimum necessary privileges.
+> **Security note:** A read-only bind mount does not make the Docker API
+> read-only. Direct access to `/var/run/docker.sock` is effectively host-root
+> access; the isolated socket proxy in `docker-compose.yml` is strongly
+> recommended.
 
 ---
 
@@ -411,7 +434,7 @@ State is stored as JSON at `STATE_FILE` (default `/data/state.json`). Mount a na
 - **Header redaction in logs:** `Authorization` and `Proxy-Authorization` headers are redacted in all log output.
 - **Secrets:** All credentials should be stored in a secrets manager (e.g., Bitwarden) and injected at runtime. Never hardcode them in compose files or Dockerfiles.
 - **Scope of deletions:** The service only deletes Pangolin rules it created itself. It will never touch rules that existed before it ran.
-- **Docker socket:** Only required for CrowdSec integration (`docker exec crowdsec cscli ...`). Mount the socket read-only (`:ro`) and keep the container locked down.
+- **Docker socket:** Only required for CrowdSec integration (`docker exec crowdsec cscli ...`). Prefer the isolated socket proxy in `docker-compose.yml`; mounting the raw socket read-only does not restrict Docker API operations.
 
 ---
 

--- a/config.env.sample
+++ b/config.env.sample
@@ -18,11 +18,9 @@ STATE_FILE=/data/state.json
 # ---------------------------------------------------------------------------
 # CrowdSec integration (optional — disabled by default)
 # ---------------------------------------------------------------------------
-# Runs cscli inside the CrowdSec container via `docker exec`. Requires the
-# Docker socket to be mounted read-only (see docker-compose.yml).
-#
-# One-time setup: ensure the pangolin-ip-rule-manager container has access to
-# the Docker socket and that the CrowdSec container is named 'crowdsec'.
+# Runs cscli inside the CrowdSec container via `docker exec`. The recommended
+# socket-proxy configuration is included in docker-compose.yml and needs no
+# host-side ownership or permission changes.
 CROWDSEC_ENABLED=false
 CROWDSEC_ALLOWLIST_NAME=pangolin-ip-rule-manager
 CROWDSEC_CACHE_TTL_SECONDS=3600
@@ -33,12 +31,12 @@ CROWDSEC_CSCLI_BIN=cscli
 # Docker socket access for CrowdSec (STRONGLY RECOMMENDED: use a socket proxy)
 # ---------------------------------------------------------------------------
 # The Docker CLI inside the container runs 'docker exec crowdsec cscli ...' to
-# reach cscli. By default it looks for /var/run/docker.sock, which requires
-# mounting the raw socket (full Docker API access — effectively root on the host).
+# reach cscli. Do not mount the raw socket unless you accept full Docker API
+# access; a read-only bind mount does not make the socket API read-only.
 #
 # A socket proxy (e.g. tecnativa/docker-socket-proxy) limits API access to exec
-# operations only. Point the Docker CLI at it by setting DOCKER_HOST, then remove
-# the docker.sock volume mount from your compose/Portainer stack.
+# operations only. Point the Docker CLI at it by setting DOCKER_HOST; no raw
+# socket mount is needed on the application service.
 #
 # See docker-compose.yml for the full socket-proxy service definition.
 #
@@ -81,5 +79,3 @@ REDIRECT_DELAY_SECONDS=3
 # suffixes (e.g. /v1, /api) and appending /ORG_ID (if ORG_ID is configured).
 # Example: https://pangolin.thecolefam.com/the-cole-fam
 PANGOLIN_DASHBOARD_URL=
-
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,10 @@ services:
   pangolin-ip-rule-manager:
     image: ghcr.io/joe-cole1/pangolin-ip-rule-manager:latest
     container_name: pangolin-ip-rule-manager
+    # Defense in depth: preserve the image's non-root identity even if its
+    # default USER is accidentally changed in a future release.
+    user: "100:101"
+    init: true
 
     environment:
       # Network
@@ -47,10 +51,9 @@ services:
       # A socket proxy limits Docker API access to exec operations only, preventing
       # this container from acting as a backdoor to the full Docker daemon.
       #
-      # To use: uncomment DOCKER_HOST below, uncomment the socket-proxy service
-      # and networks section at the bottom of this file, and remove the direct
-      # docker.sock volume mount. No code changes are required — the docker CLI
-      # picks up DOCKER_HOST automatically.
+      # To use: uncomment DOCKER_HOST below, the socket-proxy service, and the
+      # networks section at the bottom of this file. No host permission changes
+      # or raw socket mount on this service are required.
       #
       # DOCKER_HOST: tcp://socket-proxy:2375
 
@@ -70,20 +73,6 @@ services:
     volumes:
       - pangolin-ip-rule-manager-data:/data
 
-      # ---------------------------------------------------------------------------
-      # Docker socket — choose ONE of the two options below when CrowdSec is enabled
-      # ---------------------------------------------------------------------------
-      #
-      # Option A — Direct socket mount (not recommended)
-      # Gives this container full Docker API access (equivalent to root on the host).
-      # Use only if you cannot run a socket proxy.
-      #
-      # - /var/run/docker.sock:/var/run/docker.sock:ro
-      #
-      # Option B — Socket proxy (STRONGLY RECOMMENDED)
-      # Uncomment DOCKER_HOST above and the socket-proxy service below instead.
-      # This option requires no volume mount here.
-
     # Uncomment when using the socket proxy:
     # networks:
     #   - default
@@ -94,32 +83,41 @@ services:
     # ---------------------------------------------------------------------------
     # Runtime hardening
     # ---------------------------------------------------------------------------
-    # The root filesystem is read-only; only the /data volume (state) and an
-    # in-memory /tmp are writable. All Linux capabilities are dropped and
-    # privilege escalation is disabled. If you enable CrowdSec via a local
-    # `docker exec` prefix, the docker CLI may need a writable HOME — prefer the
-    # socket-proxy + DOCKER_HOST path, which keeps these flags intact.
+    # The root filesystem is read-only; only the Docker-managed /data volume and
+    # a small in-memory /tmp are writable. The image initializes new /data
+    # volumes as 100:101 and automatically tightens existing volumes to mode
+    # 0700, so no host chmod/chown step is required.
     security_opt:
       - no-new-privileges:true
     cap_drop:
       - ALL
     read_only: true
     tmpfs:
-      - /tmp
+      - /tmp:rw,noexec,nosuid,nodev,size=16m,mode=1777
+    pids_limit: 128
+    cpus: "0.5"
+    mem_limit: "256M"
 
     deploy:
       resources:
         limits:
           cpus: "0.5"
           memory: "256M"
+          pids: 128
 
     healthcheck:
       test:
-        ["CMD-SHELL", "wget -q -O - http://127.0.0.1:${LISTEN_PORT:-8080}/healthz || exit 1"]
+        ["CMD-SHELL", "wget -q -O - http://127.0.0.1:$${LISTEN_PORT:-8080}/healthz || exit 1"]
       interval: 60s
       timeout: 5s
       retries: 3
       start_period: 15s
+
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   # ---------------------------------------------------------------------------
   # Docker socket proxy (STRONGLY RECOMMENDED for CrowdSec integration)
@@ -138,7 +136,7 @@ services:
   # Uncomment this entire block and the networks section below to enable.
   #
   # socket-proxy:
-  #   image: tecnativa/docker-socket-proxy:latest
+  #   image: tecnativa/docker-socket-proxy:v0.4.2
   #   container_name: socket-proxy
   #   environment:
   #     CONTAINERS: 1

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+# Earlier releases created /data as 0755. The stable non-root owner can tighten
+# an existing named volume during an ordinary container restart, with no host
+# command required. Custom volume drivers that reject chmod remain supported;
+# the application's writable-state self-check will report any real problem.
+chmod 0700 /data 2>/dev/null || true
+
+exec "$@"


### PR DESCRIPTION
## Summary

- Harden the runtime with a stable non-root UID/GID, immutable application files, a read-only root filesystem, constrained tmpfs/resources, and no added Linux capabilities.

- Keep the Docker CLI installed unconditionally for CrowdSec while reducing the final image from 28,391,535 bytes to 23,827,622 bytes (about 16.1%).

- Make fresh installs and upgrades zero-touch: Docker initializes new named volumes correctly, and the non-root entrypoint tightens volumes from earlier releases to mode `0700` without host-side `chmod`, `chown`, or directory setup.

- Improve the example Compose health check, log rotation, PID/resource limits, and socket-proxy guidance.

## Verification

- All 200 tests passed.

- `ruff check` and `ruff format --check` passed.

- Dockerfile build checks passed for `linux/amd64` and `linux/arm64`.

- `docker compose config --quiet`, entrypoint shell syntax, and diff whitespace checks passed.

- Fresh-volume, existing-volume upgrade, read-only runtime, non-root process, and `/healthz` checks passed with the Compose hardening flags.

## Documentation

- Updated the README, sample environment configuration, Compose comments, and contributor guidance to document the zero-touch volume behavior and safer Docker socket proxy setup.

## Migration and risk

- No user action or host command is required for a normal image update. Existing state, environment variables, ports, volume names, and the unconditional Docker CLI remain unchanged.

- Updating to the revised example Compose file is optional but recommended to adopt the additional runtime limits and logging controls.

- Existing CrowdSec socket-proxy configurations remain compatible. Direct raw Docker socket access is no longer recommended because a read-only bind mount does not restrict Docker API operations.
