### PR TITLE
chore: rely on image health check in compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,13 +189,6 @@ services:
     cpus: "0.5"
     mem_limit: "256M"
 
-    healthcheck:
-      test: ["CMD-SHELL", "wget -q -O - http://127.0.0.1:$${LISTEN_PORT:-8080}/healthz || exit 1"]
-      interval: 60s
-      timeout: 5s
-      retries: 3
-      start_period: 15s
-
     volumes:
       - pangolin-ip-rule-manager-data:/data
 
@@ -217,6 +210,9 @@ The named volume is created and permissioned by Docker from the image metadata;
 the non-root entrypoint also tightens volumes from earlier releases to mode
 `0700` automatically. Fresh installs and upgrades require no host-side `chmod`,
 `chown`, directory creation, or other setup commands.
+
+The image includes its own `/healthz` health check, so Docker and Compose report
+container health without a `healthcheck` override in the Compose file.
 
 ### Finding Your Resource IDs
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,13 +105,8 @@ services:
           memory: "256M"
           pids: 128
 
-    healthcheck:
-      test:
-        ["CMD-SHELL", "wget -q -O - http://127.0.0.1:$${LISTEN_PORT:-8080}/healthz || exit 1"]
-      interval: 60s
-      timeout: 5s
-      retries: 3
-      start_period: 15s
+    # The image provides the /healthz health check. Define healthcheck here only
+    # when this deployment needs to override the image's timing or test.
 
     logging:
       driver: json-file
@@ -141,11 +136,18 @@ services:
   #   environment:
   #     CONTAINERS: 1
   #     EXEC: 1
+  #     PING: 1
   #     POST: 1
   #   volumes:
   #     - /var/run/docker.sock:/var/run/docker.sock:ro
   #   networks:
   #     - socket-proxy
+  #   healthcheck:
+  #     test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:2375/_ping"]
+  #     interval: 30s
+  #     timeout: 5s
+  #     retries: 3
+  #     start_period: 10s
   #   restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
## Summary

- Remove the redundant application health-check override from the example Compose file and rely on the health check versioned with the application image.

- Add a read-only `/_ping` health check to the optional Docker socket proxy so it becomes unhealthy when it cannot reach the Docker daemon through the mounted socket.

- Make the proxy's existing `PING` permission explicit in the example configuration.

## Verification

- `docker compose config --quiet` passed with representative required environment values.

- Dockerfile build checks passed with no warnings.

- The built application image retains the expected `/healthz` command, 60-second interval, 5-second timeout, 15-second start period, and three retries.

- The pinned socket-proxy v0.4.2 image contains the `wget` command used by the probe, and its upstream HAProxy configuration permits and forwards `/_ping` to the Docker socket.

- Git whitespace validation passed.

## Documentation

- Update the README Compose example and clarify that Docker automatically uses the application image's built-in health check.

## Migration and risk

- No user action is required. Existing application containers continue to inherit the image health check.

- Users who enable the optional socket proxy can adopt its new health-check block without host commands or application configuration changes.

- The probe uses Docker's read-only `/_ping` endpoint and does not create, modify, or execute anything through the Docker API.
